### PR TITLE
feat(internal): Add schema check to ci

### DIFF
--- a/.github/workflows/check_schema.yaml
+++ b/.github/workflows/check_schema.yaml
@@ -1,0 +1,30 @@
+name: Check Schema
+
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ 'main' ]
+
+jobs:
+  check-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Setup poetry
+        run: |
+          pipx ensurepath
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          pipx install poetry
+          poetry self add poetry-plugin-shell
+      - name: Install dependencies
+        run: |
+          poetry install
+
+      - name: Check schema
+        run: |
+          poetry run tools/ci/check-schemas.sh

--- a/tools/ci/check-schemas.sh
+++ b/tools/ci/check-schemas.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Runs validator, and composes markdown summary for github action
+
+if [ -z "$GITHUB_STEP_SUMMARY" ]
+then
+    GITHUB_STEP_SUMMARY=$(mktemp)
+fi
+
+declare -i fail=0
+WORKFLOW_FILES=$(find . -name '*workflow*.yaml')
+AGENT_FILES=$(find . -name '*agents*.yaml')
+
+
+echo "|Filename|Type|Stats|" >> "$GITHUB_STEP_SUMMARY"
+echo "|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+
+
+# Check workflows
+# TODO Consolidate duplication
+for f in $WORKFLOW_FILES
+do
+    if ! beeAI validate tools/workflow_schema.json "$f"
+    then
+      RESULT="FAIL ❌"
+      fail+=1
+    else
+      RESULT="PASS ✅"
+    fi
+    echo "|$f|workflow|$RESULT|" >> "$GITHUB_STEP_SUMMARY"
+done
+
+# Check agents
+for f in $AGENT_FILES
+do
+    if ! beeAI validate tools/agent_schema.json "$f"
+    then
+      RESULT="FAIL ❌"
+      fail+=1
+    else
+      RESULT="PASS ✅"
+    fi
+    echo "|$f|agent|$RESULT|" >> "$GITHUB_STEP_SUMMARY"
+done
+
+if [ -z "$CI" ];
+ then
+  cat "$GITHUB_STEP_SUMMARY"
+fi
+
+exit $fail


### PR DESCRIPTION
Adds CI check for schema validation ([CLICK FOR EXAMPLE RUN](https://github.com/i-am-bee/bee-hive/actions/runs/13197461780))

Notes:
* we don't currently enforce tests pass via a branch protection rule - in fact we can't in a private repo
* Added as separate task to make it clear this is a different check (as we get set up)
* The crewai agent also uses a default name 'agents.yaml' for it's own agent definition! This will be renamed in a future PR

Partially addresses #178 