### PR TITLE
fix(demos): Fix demos after refactor

### DIFF
--- a/maestro-demos/agents/crewai/activity_planner/__init__.py
+++ b/maestro-demos/agents/crewai/activity_planner/__init__.py
@@ -1,0 +1,1 @@
+import * from activity-planner

--- a/maestro-demos/demos/activity-planner-crewai.ai/run.py
+++ b/maestro-demos/demos/activity-planner-crewai.ai/run.py
@@ -3,11 +3,11 @@
 import yaml
 import sys
 import os
-from bee_hive import Workflow
+from maestro import Workflow
 
 
 # TODO Add agent path to path explicitly - this should be found on path, but may require base change
-sys.path.append("bee-hive-demos/agents/crewai/activity_planner")
+sys.path.append("agents/crewai/activity_planner")
 
 def test_agent_runs() -> None:
     """
@@ -26,7 +26,7 @@ def test_agent_runs() -> None:
         raise RuntimeError("Unable to create agents") from excep
     result = workflow.run()
     print(result)
-        
+
 if __name__ == "__main__":
     test_agent_runs()
 

--- a/maestro-demos/pyproject.toml
+++ b/maestro-demos/pyproject.toml
@@ -1,0 +1,46 @@
+[tool.poetry]
+name = "maestro_demos"
+version = "0.1.0"
+description = "Demos for maestro"
+authors = ["IBM"]
+license = "Apache 2.0"
+readme = "README.md"
+packages = [
+    # TODO - Packaging demos allows them to be run after a pip install 
+    { include = "activity_planner", from = "bee-hive-demos/agents/crewai" }
+]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = ">= 3.11, < 3.13"
+openai = "^1.61.1"
+pyyaml = "^6.0.2"
+python-dotenv = "^1.0.1"
+jsonschema = "^4.23.0"
+docopt-ng = "^0.9.0"
+# TODO Required by demos -- can split up, but then extra steps to install. See https://github.com/i-am-bee/bee-hive/issues/188
+langchain-community = "^0.3.16"
+duckduckgo-search = "^7.3.0"
+crewai = "^0.100.1"
+crewai-tools = "^0.33.0"
+# TODO Update to main repo (or path) after other changes merged
+# maestro = {path = "../maestro", develop = true}
+maestro = { git = "https://github.com/planetf1/beeai-labs.git", branch = "fixci", subdirectory = "maestro" }
+
+[tool.poetry.group.dev.dependencies]
+black = "^24.10.0"
+
+[tool.poetry.group.test.dependencies]
+pytest = "^8.3.4"
+pytest-mock = "^3.14.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "-v -s --ignore=framework"
+#rootpath = "bee-hive"
+
+[tool.poetry.scripts]
+# TODO Add scripts to run demos here


### PR DESCRIPTION
Fixes demos after refactoring & splitting up of demos/base

- Reintroduces a `pyproject.toml` in `maestro-demos`
- Fixes up demos to work relative to demos directory

To run demos (relative to top level directory)
 - **Ensure no virtual environment currently active**
 - `cd maestro-demos` 
 - `poetry install`
- `agents/crewai/activity_planner/activity_planner.py` - runs the test crewai agent (standalone)
 - `demos/activity-planner-crewai.ai/run.py`- runs the crewai workflow demo
 
 Caveats
  - The current `pyproject.toml` contains a reference to this fork. A LATER PR will look at whether this can be changed to main, or (better) a subdirectory dependency can be added
  - Ensure you are using the correct project definition and virtual environment (since this is now a monorepo)
  - vscode may not correctly run demos without additional plugins to support python/poetry monorepos
  - no readme update since there is further work needed to integrate into the broader demos