### PR TITLE
feat(internal): Automated test of demo

### DIFF
--- a/.github/workflows/maestro_demotest.yaml
+++ b/.github/workflows/maestro_demotest.yaml
@@ -41,3 +41,5 @@ jobs:
           cd maestro
           poetry run demos/demos/activity-planner-crewai.ai/run.py
           # TODO: Add a way to check the output of the demo
+        env:
+          MAESTRO_DEMO_OLLAMA_MODEL: ollama/llama3.2:3b

--- a/.github/workflows/maestro_demotest.yaml
+++ b/.github/workflows/maestro_demotest.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Run CrewAI workflow
         run: |
           cd maestro
-          poetry run demos/demos/activity-planner-crewai.ai/run.sh
+          poetry run demos/demos/activity-planner-crewai.ai/run.py
           # TODO: Add a way to check the output of the demo

--- a/.github/workflows/maestro_demotest.yaml
+++ b/.github/workflows/maestro_demotest.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: pydantic/ollama-action@v3
         with:
           # Small model - 7GB max in this runner
-          model: llama3.1:8b
+          model: llama3.1:latest
       # TODO: generalise for other demos 
       - name: Run CrewAI workflow
         run: |

--- a/.github/workflows/maestro_demotest.yaml
+++ b/.github/workflows/maestro_demotest.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Run CrewAI workflow
         run: |
           cd maestro
-          poetry run demos/activity-planner-crewai.ai/run.sh
+          poetry run demos/demos/activity-planner-crewai.ai/run.sh
           # TODO: Add a way to check the output of the demo

--- a/.github/workflows/maestro_demotest.yaml
+++ b/.github/workflows/maestro_demotest.yaml
@@ -1,0 +1,43 @@
+name: Maestro Demo Test (ollama only)
+
+on:
+  push:
+    branches: [ 'main' ]
+    paths:
+    - 'maestro/**'
+  pull_request:
+    branches: [ 'main' ]
+    paths:
+    - 'maestro/**'
+    - '.github/workflows/**'
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Setup poetry
+        run: |
+          pipx ensurepath
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          pipx install poetry
+          poetry self add poetry-plugin-shell
+      - name: Install dependencies
+        run: |
+          cd maestro
+          poetry install
+      - name: Install Ollama
+        uses: pydantic/ollama-action@v3
+        with:
+          # Small model - 7GB max in this runner
+          model: llama3.2:1b
+      # TODO: generalise for other demos 
+      - name: Run CrewAI workflow
+        run: |
+          cd maestro
+          poetry run demos/activity-planner-crewai.ai/run.sh
+          # TODO: Add a way to check the output of the demo

--- a/.github/workflows/maestro_demotest.yaml
+++ b/.github/workflows/maestro_demotest.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: pydantic/ollama-action@v3
         with:
           # Small model - 7GB max in this runner
-          model: llama3.2:1b
+          model: llama3.1:8b
       # TODO: generalise for other demos 
       - name: Run CrewAI workflow
         run: |

--- a/maestro/demos/agents/crewai/activity_planner/activity_planner.py
+++ b/maestro/demos/agents/crewai/activity_planner/activity_planner.py
@@ -15,6 +15,7 @@ Usage:
 # TODO decorators use config/agents.yaml & config/tasks.yaml. Former clashes in name which causes yaml validation error
 # TODO decorators cause PyLance errors
 
+import os
 from crewai import Agent, Crew, Task, Process, LLM
 from crewai.project import CrewBase, agent, task, crew
 from crewai.tools import tool
@@ -30,8 +31,10 @@ class ActivityPlannerCrew:
     """
 
     # TODO Set model/URL from configuration
-    llm = LLM(model="ollama/llama3.1", base_url="http://localhost:11434")
-
+    llm = LLM(
+        model=os.getenv("MAESTRO_DEMO_OLLAMA_MODEL", "ollama/llama3.1"),
+        base_url=os.getenv("MAESTRO_DEMO_OLLAMA_URL", "http://localhost:11434")
+    )
     @tool("DuckDuckGo")
     # TODO PyLance issue - missing self() but fails with crewai decorators if added
     def ddg_search(question: str) -> str:

--- a/maestro/demos/demos/activity-planner.ai/compose.yaml
+++ b/maestro/demos/demos/activity-planner.ai/compose.yaml
@@ -1,0 +1,1 @@
+include


### PR DESCRIPTION
POC of running a basic demo
 - Runs the crewAI activity planner workflow (basic, does not use bee)
 - Workflow launches Ollama only (not bee stack)
 - Uses llama3.2:1b model 
 - no checking of output
 
 Based on results of this (after discussion) could consider
 - Generalizing to search for demos matching certain criteria
 - Adding bee-stack (this might require a custom action, use of a composite compose, or k8s, perhaps KinD)
 - how to define expected results
 
 Other tests are also possible that stub out external calls to ollama