### PR TITLE
Add input step

### DIFF
--- a/maestro/schemas/workflow_schema.json
+++ b/maestro/schemas/workflow_schema.json
@@ -95,7 +95,7 @@
                           "description": "template string for next prompt, {prompt} and {respomse} are replaced by the previos prompt and the user response"
                       }
                     }
-                  }
+                  },
                   "condition": {
                     "type": "array",
                     "description": "if/then/else or case/do/default condition",
@@ -125,8 +125,7 @@
                   }
                 },
                 "required": [
-                    "name",
-                    "agent"
+                    "name"
                 ]
               }
             }

--- a/maestro/schemas/workflow_schema.json
+++ b/maestro/schemas/workflow_schema.json
@@ -82,6 +82,20 @@
                     "type": "string",
                     "description": "the agent for this step"
                   },
+                  "input": {
+                    "type": "object",
+                    "description": "user input",
+                    "properties": {
+                      "prompt": {
+                        "type": "string",
+                        "description": "input prompt string"
+                      },
+                      "template": {
+                        "type": "string",
+                          "description": "template string for next prompt, {prompt} and {respomse} are replaced by the previos prompt and the user response"
+                      }
+                    }
+                  }
                   "condition": {
                     "type": "array",
                     "description": "if/then/else or case/do/default condition",

--- a/maestro/src/step.py
+++ b/maestro/src/step.py
@@ -15,12 +15,16 @@ class Step:
     def __init__(self, step):
         self.step_name = step["name"]
         self.step_agent = step.get("agent")
+        self.step_input = step.get("input")
         self.step_condition = step.get("condition")
 
     def run(self, prompt):
         output = {"prompt": prompt}
         if self.step_agent:
             prompt = self.step_agent.run(prompt)
+            output["prompt"] = prompt
+        if self.step_input:
+            prompt = self.input(prompt)
             output["prompt"] = prompt
         if self.step_condition:
             next = self.evaluate_condition(prompt)
@@ -50,3 +54,9 @@ class Step:
             else:
                 default = condition.get("do")
         return default
+
+    def input(self, prompt):
+        user_prompt = self.step_input.get("prompt")
+        response = input(user_prompt)
+        template = self.step_input.get("template")
+        return template.replace("{prompt}", prompt).replace("{response}", response) 

--- a/maestro/tests/yamls/workflows/input_workflow.yaml
+++ b/maestro/tests/yamls/workflows/input_workflow.yaml
@@ -1,0 +1,29 @@
+apiVersion: maestro/v1
+kind: Workflow
+metadata:
+  name: input_workflow
+  labels:
+    app: input
+spec:
+  strategy:
+    type: condition
+  template:
+    metadata:
+      name: input_workflow
+      labels:
+        app: example
+        use-case: test
+    agents:
+        - test1
+        - test2
+    prompt: Select a number 1 through 6
+    exception: step4
+    steps:
+      - name: select
+        agent: test1
+      - name: input
+        input:
+          prompt: "Gess the number 1 through 6: "
+          template: Is the number {prompt} is same as {response}?  
+      - name: compare
+        agent: test2

--- a/maestro/tests/yamls/workflows/input_workflow.yaml
+++ b/maestro/tests/yamls/workflows/input_workflow.yaml
@@ -23,7 +23,7 @@ spec:
         agent: test1
       - name: input
         input:
-          prompt: "Gess the number 1 through 6: "
+          prompt: "Guess the number 1 through 6: "
           template: Is the number {prompt} is same as {response}?  
       - name: compare
         agent: test2


### PR DESCRIPTION
fix #223 

Add `input` in the step.  It does:  

1. shows an input prompt and wait for user input
2.  generate the next prompt by replacing the `{prompt}` and `{response}`. in the template

An example of the input step is:
```
      - name: input
        input:
          prompt: "Guess the number 1 through 6: "
          template: Is the number {prompt} is same as {response}?  
```