### PR TITLE
fix display error for input

### DIFF
--- a/maestro/src/step.py
+++ b/maestro/src/step.py
@@ -56,7 +56,8 @@ class Step:
         return default
 
     def input(self, prompt):
-        user_prompt = self.step_input.get("prompt")
-        response = input(user_prompt)
+        user_prompt = self.step_input.get("prompt").replace("{prompt}", str(prompt)) 
+        response = input(user_prompt) 
         template = self.step_input.get("template")
-        return template.replace("{prompt}", prompt).replace("{response}", response) 
+        formatted_response = template.replace("{prompt}", prompt).replace("{response}", response)
+        return formatted_response


### PR DESCRIPTION
Previously in the input function, we are mapping the prompt after printing to the user, which means the printed  output would  dispaly the string literal {prompt}:

Response:
Here are the retrieved papers:
{prompt}

Select the papers you want to summarize by entering numbers (comma-separated):

I've changed the order slightly to allow the replacement to happen before displaying to user, so we see this instead:
Here are the retrieved papers:
["Observation of a zero-energy excitation mode in the open Dicke model", "Learning Smooth and Expressive Interatomic Potentials for Physical", "When Wyner and Ziv Met Bayes in Quantum-Classical Realm", "Real operator systems", "Universal quantum computation by interference of monochromatic", ]

Select the papers you want to summarize by entering the full title name