### PR TITLE
make CI running demos the same

### DIFF
--- a/.github/workflows/maestro_demo-tests.yaml
+++ b/.github/workflows/maestro_demo-tests.yaml
@@ -40,8 +40,8 @@ jobs:
       - name: Run weather.ai workflow
         run: |
           cd maestro
-          demos/workflows/weather-checker.ai/doctor.sh
-          demos/workflows/weather-checker.ai/test.sh
+          poetry run demos/workflows/weather-checker.ai/doctor.sh
+          poetry run demos/workflows/weather-checker.ai/test.sh
         env:
           MAESTRO_DEMO_OLLAMA_MODEL: ollama/llama3.2:3b
       - name: Run summary.ai workflow


### PR DESCRIPTION
@george-lhj let's make all demos the same. Changed it here but for future all demos should be run the same way (as much as possible) this is why I suggested in issue #244 that we create a `tools/run-demos.sh` that iterates over the `demos/workflows` and runs each demo in turn. This bash script can then be called from `.github/workflows/maestro_demo-tests.yaml`.

Thanks.