### PR TITLE
Add deploy class

### DIFF
--- a/maestro/deployments/Dockerfile
+++ b/maestro/deployments/Dockerfile
@@ -43,12 +43,12 @@ RUN python3.11 -m ensurepip --upgrade
 RUN python3.11 -m pip install openai pyyaml python-dotenv flask --no-cache-dir --upgrade && \
     python3.11 -m pip uninstall -y pip
 
-COPY maestro ./maestro
-COPY entrypoint.sh .
-COPY run_workflow.py .
-COPY entrypoint_api.sh .
-COPY api.py .
-COPY maestro.html ./static/maestro.html
+COPY src ./src
+COPY tmp/entrypoint_api.sh .
+COPY tmp/api.py .
+COPY tmp/maestro.html ./static/maestro.html
+COPY tmp/agents.yaml ./src/agents.yaml
+COPY tmp/workflow.yaml ./src/workflow.yaml
 
 RUN chown -R 1000:100 /usr/src/app &&\
     mkdir /usr/src/app/media && chown 1000:100 /usr/src/app/media

--- a/maestro/deployments/api.py
+++ b/maestro/deployments/api.py
@@ -6,7 +6,7 @@ import sys
 import io
 
 import yaml
-from maestro.workflow import Workflow
+from src.workflow import Workflow
 
 app = Flask(__name__)
 
@@ -15,36 +15,11 @@ def parse_yaml(file_path):
         yaml_data = list(yaml.safe_load_all(file))
     return yaml_data
 
-@app.route('/', methods=['POST'])
+@app.route('/', methods=['GET'])
 def process_workflow():
-    if request.method == 'POST':
-        # Check if a file was uploaded
-        if 'agents' not in request.files:
-            return 'No agent definition'
-
-        agents = request.files['agents']
-
-        # Check if the file has a filename
-        if agents.filename == '':
-            return 'No agents file name'
-
-        # Save the file to the server
-        agents.save("agents")
-
-        if 'workflow' not in request.files:
-            return 'No agent definition'
-
-        workflow = request.files['workflow']
-
-        # Check if the file has a filename
-        if workflow.filename == '':
-            return 'No workflow file name'
-
-        # Save the file to the server
-        workflow.save("workflow")
-
-        agents_yaml = parse_yaml("agents")
-        workflow_yaml = parse_yaml("workflow")
+    if request.method == 'GET':
+        agents_yaml = parse_yaml("src/agents.yaml")
+        workflow_yaml = parse_yaml("src/workflow.yaml")
         try:
             workflow_instance = Workflow(agents_yaml, workflow_yaml[0])
         except Exception as excep:
@@ -56,14 +31,11 @@ def process_workflow():
         sys.stdout = sys.__stdout__
 
         response = {
-            'workflow': workflow.filename,
-            'agents': agents.filename,
             'output': output.getvalue()
         }
         if os.getenv("DEBUG"):
             return response
         else:
-            html = "<html><style>div { white-space: pre-wrap;}</style> <div>"+ output.getvalue()+"</div></html>"
-            return html
+            return output.getvalue()
 if __name__ == '__main__':
     app.run(host='0.0.0.0')

--- a/maestro/deployments/deployment.yaml
+++ b/maestro/deployments/deployment.yaml
@@ -21,16 +21,4 @@ spec:
         env:
         - name: DUMMY
           value: dummyvalue
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: maestro
-spec:
-  selector:
-    app: maestro
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 5000
-  type: NodePort
+

--- a/maestro/deployments/entrypoint.sh
+++ b/maestro/deployments/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-python3.11 run_workflow.py "$@"
-

--- a/maestro/deployments/maestro.html
+++ b/maestro/deployments/maestro.html
@@ -4,23 +4,24 @@
     <title>Maestro</title>
 </head>
 <style>
-    body {color: black; background-color: lightblue;}
+    body {color: black; background-color: lightgreen;}
+    frame {
+        border: 1px solid black;
+        background-color: yellow;
+    }
 </style>
 <body>
-    <h1>
-        Maestro
-    </h1>
-    <form action="/" method="post" enctype="multipart/form-data">
-        <h2>Select an agent definition file</h2>
-        <div style="display: flex;">
-            <input type="file" name="agents"  placeholder="Agent definition" style="color: blue;">
-        </div>
-        <h2>Select a workflow definition file</h2>
-        <div style="display: flex;">
-            <input type="file" name="workflow"  placeholder="Workflow definition" style="color: blue;">
-        </div>
-        <h2>Run workflow</h2>
-        <input type="submit" value="Ececute" style="color: green;">
+    <div id="output"></div>
+    <form action="/static/maestro.html" method="get">
+        <input type="submit" value="Re-run">
     </form>
+    <script>
+        async function fetchData() {
+            const response = await fetch('/');
+            const data = await response.text();
+            document.getElementById('output').innerText = data;
+        }
+        fetchData();
+    </script>
 </body>
 </html>

--- a/maestro/deployments/maestro.sh
+++ b/maestro/deployments/maestro.sh
@@ -10,7 +10,7 @@ fi
 
 if [ "$1" == "build" ]; then
     echo "Building..."
-    $cmd build $flags -t maestro .
+    $cmd build $flags -t maestro -f Dockerfile ..
 elif [ "$1" == "deploy" ]; then
     echo "Deploying..."
     env=""

--- a/maestro/deployments/service.yaml
+++ b/maestro/deployments/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: maestro
+spec:
+  selector:
+    app: maestro
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5000
+  type: NodePort

--- a/maestro/src/__init__.py
+++ b/maestro/src/__init__.py
@@ -19,7 +19,9 @@ dotenv.load_dotenv()
 from .workflow import Workflow
 from .bee_agent import BeeAgent
 from .agent import save_agent, restore_agent, remove_agent
+from .deploy import Deploy
 
 __all__ = {
-    "Workflow"
+    "Workflow",
+    "Deploy"
 }

--- a/maestro/src/deploy.py
+++ b/maestro/src/deploy.py
@@ -93,7 +93,7 @@ class Deploy:
         subprocess.run(["kubectl", "apply", "-f", "deployment.yaml"])
         subprocess.run(["kubectl", "apply", "-f", "service.yaml"])
 
-if __name__ == '__main__':
+#if __name__ == '__main__':
     #deploy = Deploy("../tests/examples/condition_agents.yaml", "../tests/examples/condition_workflow.yaml", "BEE_API_KEY=sk-proj-testkey BEE_API=http://192.168.86.45:4000", "127.0.0.1:5000")
     #deploy.deploy_to_docker()
     #deploy = Deploy("../tests/examples/condition_agents.yaml", "../tests/examples/condition_workflow.yaml", "BEE_API_KEY=sk-proj-testkey BEE_API=http://192.168.86.45:4000")

--- a/maestro/src/deploy.py
+++ b/maestro/src/deploy.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# Copyright © 2025 IBM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os, dotenv
+import shutil
+import subprocess
+import yaml
+
+# cmd="podman"
+# env="BEE_API_KEY=sk-proj-testkey BEE_API=http://192.168.86.45:4000"
+# target="127.0.0.1:5000"
+
+dotenv.load_dotenv() #TODO is this needed now that __init__.py in package runs this?
+
+def env_array_docker(str_envs):
+    env_array = str_envs.split()
+    env_args = []
+    for env in env_array:
+        env_args.append("-e")
+        env_args.append(env)
+    return(env_args)
+
+def flag_array_build(str_flags):
+    flag_array = str_flags.split()
+    flags = []
+    for flag in flag_array:
+        key, value = flag.split("=")
+        flags.append(key)
+        flags.append(value)
+    return(flags)
+
+def create_docker_args(cmd, target, env):
+    arg = [f"{cmd}", "run", "-d", "-p", f"{target}:5000"]
+    arg.extend(env_array_docker(env))
+    arg.append("maestro")
+    return arg
+
+def create_build_args(cmd, flags):
+    arg = [f"{cmd}", "build"]
+    if flags:
+        print(flags)
+        arg.extend(flag_array_build(flags))
+    arg.extend(["-t", "maestro", "-f", "Dockerfile", ".."])
+    return arg
+
+def update_yaml(yaml_file, str_envs):
+    with open(yaml_file, 'r') as f:
+        data = yaml.safe_load(f)
+    pairs = str_envs.split()
+    for pair in pairs:
+        key, value = pair.split('=')
+        data['spec']['template']['spec']['containers'][0]['env'].append({'name': key, 'value': value})
+    with open(yaml_file, 'w') as f:
+        yaml.safe_dump(data, f)
+
+class Deploy:
+    def __init__(self, agent_defs, workflow_defs, env=None, target=None):
+        self.agent = agent_defs
+        self.workflow = workflow_defs
+        self.env = env
+        self.target = target or "127.0.0.1:5000"
+        self.cmd = os.getenv("CONTAINER_CMD", "docker")
+        self.flags = os.getenv("BUILD_FLAGS")
+
+    def build_image(self, agent, workflow):
+        shutil.copytree("../deployments", "../tmp", dirs_exist_ok=True)
+        shutil.copy(agent, "../tmp/agents.yaml")
+        shutil.copy(workflow, "../tmp/workflow.yaml")
+
+        os.chdir("../tmp")
+        subprocess.run(create_build_args(self.cmd, self.flags))
+
+    def deploy_to_docker(self):
+        self.build_image(self.agent, self.workflow)
+        subprocess.run(create_docker_args(self.cmd, self.target, self.env))
+    
+    def deploy_to_kubernetes(self):
+        self.build_image(self.agent, self.workflow)
+        update_yaml("deployment.yaml", self.env)
+        subprocess.run(["kubectl", "apply", "-f", "deployment.yaml"])
+        subprocess.run(["kubectl", "apply", "-f", "service.yaml"])
+
+if __name__ == '__main__':
+    #deploy = Deploy("../tests/examples/condition_agents.yaml", "../tests/examples/condition_workflow.yaml", "BEE_API_KEY=sk-proj-testkey BEE_API=http://192.168.86.45:4000", "127.0.0.1:5000")
+    #deploy.deploy_to_docker()
+    #deploy = Deploy("../tests/examples/condition_agents.yaml", "../tests/examples/condition_workflow.yaml", "BEE_API_KEY=sk-proj-testkey BEE_API=http://192.168.86.45:4000")
+    #deploy.deploy_to_kubernetes()


### PR DESCRIPTION
Add new `Deploy` class.

The constructor takes agent yaml, workflow yaml files and necessary runtime environment variables.
There are 2 deploy time environment variables. 

1. CONTAINER_CMD: command to build container image (docker, podman, nerdctl, ...) 
2. BUILD_FLAGS: flags necessary to build the container image (--namespace=k8s.io, ...

Here is an example
```
deploy = Deploy("../tests/examples/condition_agents.yaml", "../tests/examples/condition_workflow.yaml", "BEE_API_KEY=sk-proj-testkey BEE_API=http://192.168.86.45:4000")
```
It has 2 instance methods.

```
deploy.deploy_to_docker()
deploy_to_kubernetes()
```

After these method are executed, web interface is available at http/ <host address:port>/static/maestro.html
The host address and port are
Docker: 127.0.0.1:5000
Kubernetes: 127.0.0.1:"nodeport number of maestro service"
 
