### PR TITLE
Add kind support

### DIFF
--- a/maestro/deployments/service.yaml
+++ b/maestro/deployments/service.yaml
@@ -9,4 +9,5 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 5000
+      nodePort: 30051
   type: NodePort

--- a/maestro/src/deploy.py
+++ b/maestro/src/deploy.py
@@ -90,6 +90,12 @@ class Deploy:
     def deploy_to_kubernetes(self):
         self.build_image(self.agent, self.workflow)
         update_yaml("deployment.yaml", self.env)
+        image_tag_command  = os.getenv("IMAGE_TAG_CMD")
+        if image_tag_command:
+            subprocess.run(image_tag_command.split())
+        image_push_command  = os.getenv("IMAGE_PUSH_CMD")
+        if image_push_command:
+            subprocess.run(image_push_command.split())
         subprocess.run(["kubectl", "apply", "-f", "deployment.yaml"])
         subprocess.run(["kubectl", "apply", "-f", "service.yaml"])
 

--- a/maestro/tests/integration/kind-config.yaml
+++ b/maestro/tests/integration/kind-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30051
+    hostPort: 30051
+    listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
+    protocol: tcp # Optional, defaults to tcp
+- role: worker


### PR DESCRIPTION
This PR add an easy configuration for Kind deployment.

create a kind cluster using the `kind-config.yaml`.
```
kind create cluster --config tests/integration/kind-config.yaml
```
set the following environment variables (`docker` can be `podman`, too)
```
IMAGE_PUSH_CMD='kind load docker-image docker.io/library/maestro:latest'
IMAGE_TAG_CMD='docker tag localhost/maestro:latest docker.io/library/maestro:latest'
```

Execute python
```
 deploy = Deploy("../tests/examples/condition_agents.yaml", "../tests/examples/condition_workflow.yaml", "BEE_API_KEY=sk-proj-testkey BEE_API=http://192.168.86.45:4000")
 deploy.deploy_to_kubernetes()
```

The web UI is at `http://127.0.0.1:30051/static/maestro.html`