### PR TITLE
Add parallel

### DIFF
--- a/maestro/schemas/workflow_schema.json
+++ b/maestro/schemas/workflow_schema.json
@@ -113,6 +113,13 @@
                         }
                       }
                     }
+                  },
+                  "parallel": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "agent"
+                    }
                   }
                 },
                 "required": [

--- a/maestro/src/agent.py
+++ b/maestro/src/agent.py
@@ -4,6 +4,7 @@
 from abc import abstractmethod
 import os
 import pickle
+import asyncio
 
 class Agent:
     """
@@ -28,7 +29,7 @@ class Agent:
         self.instructions = f"{self.instructions} Output must be in format: {self.agent_output}" if self.agent_output else self.instructions
 
     @abstractmethod
-    def run(self, prompt: str) -> str:
+    async def run(self, prompt: str) -> str:
         """
         Runs the agent with the given prompt.
         Args:
@@ -36,7 +37,7 @@ class Agent:
         """
 
     @abstractmethod
-    def run_streaming(self, prompt: str) -> str:
+    async def run_streaming(self, prompt: str) -> str:
         """
         Runs the agent in streaming mode with the given prompt.
         Args:

--- a/maestro/src/bee_agent.py
+++ b/maestro/src/bee_agent.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os, dotenv
+import asyncio
 
 from openai import AssistantEventHandler, OpenAI
 from openai.types.beta import AssistantStreamEvent
@@ -49,7 +50,7 @@ class BeeAgent(Agent):
 
         self.agent_id = assistant.id
 
-    def run(self, prompt: str) -> str:
+    async def run(self, prompt: str) -> str:
         """
         Runs the bee agent with the given prompt.
         Args:

--- a/maestro/src/crewai_agent.py
+++ b/maestro/src/crewai_agent.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
+import asyncio
 
 from .agent import Agent
 
@@ -38,7 +39,7 @@ class CrewAIAgent(Agent):
             raise(e)
 
 
-    def run(self, prompt: str) -> str:
+    async def run(self, prompt: str) -> str:
         """
         Executes the CrewAI agent with the given prompt. The agent's `kickoff` method is called with the input.
        

--- a/maestro/src/mock_agent.py
+++ b/maestro/src/mock_agent.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import asyncio
 
 import dotenv
 from openai import AssistantEventHandler, OpenAI
@@ -35,7 +36,7 @@ class MockAgent(Agent):
         print(f"Mock agent: name={self.agent_name}, model={self.agent_model}, description={self.agent_desc}, tools={self.agent_tools}, instructions={self.instructions}")
         self.agent_id = self.agent_name
 
-    def run(self, prompt: str) -> str:
+    async def run(self, prompt: str) -> str:
         """
         Runs the bee agent with the given prompt.
         Args:

--- a/maestro/src/step.py
+++ b/maestro/src/step.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dotenv
+import asyncio
 
 dotenv.load_dotenv()
 
@@ -17,11 +18,12 @@ class Step:
         self.step_agent = step.get("agent")
         self.step_input = step.get("input")
         self.step_condition = step.get("condition")
+        self.step_parallel = step.get("parallel")
 
-    def run(self, prompt):
+    async def run(self, prompt):
         output = {"prompt": prompt}
         if self.step_agent:
-            prompt = self.step_agent.run(prompt)
+            prompt = await self.step_agent.run(prompt)
             output["prompt"] = prompt
         if self.step_input:
             prompt = self.input(prompt)
@@ -29,6 +31,9 @@ class Step:
         if self.step_condition:
             next = self.evaluate_condition(prompt)
             output["next"] = next
+        if self.step_parallel:
+            prompt = await self.parallel(prompt)
+            output["prompt"] = prompt
         return output
 
     def evaluate_condition(self, prompt):
@@ -61,3 +66,18 @@ class Step:
         template = self.step_input.get("template")
         formatted_response = template.replace("{prompt}", prompt).replace("{response}", response)
         return formatted_response
+
+    async def parallel(self, prompt):
+        #results = await asyncio.gather(*[asyncio.create_task(agent.run(prompt)) for agent in self.step_parallel])
+        results = []
+        for agent in self.step_parallel:
+            results.append(asyncio.create_task(agent.run(prompt)))
+        for r in results:
+            y =await r
+            print(y)
+
+        #result_array = []
+        #for result in results:
+        #    result_array.append(result)
+        #return str(result_array)
+

--- a/maestro/src/step.py
+++ b/maestro/src/step.py
@@ -69,15 +69,11 @@ class Step:
 
     async def parallel(self, prompt):
         #results = await asyncio.gather(*[asyncio.create_task(agent.run(prompt)) for agent in self.step_parallel])
-        results = []
+        waits = []
         for agent in self.step_parallel:
-            results.append(asyncio.create_task(agent.run(prompt)))
-        for r in results:
-            y =await r
-            print(y)
-
-        #result_array = []
-        #for result in results:
-        #    result_array.append(result)
-        #return str(result_array)
+            waits.append(asyncio.create_task(agent.run(prompt)))
+        results = []
+        for wait in waits:
+            results.append(await wait)
+        return str(results)
 

--- a/maestro/src/workflow.py
+++ b/maestro/src/workflow.py
@@ -56,10 +56,10 @@ class Workflow:
         self.agent_defs = agent_defs
         self.workflow = workflow
 
-    def run(self):
+    async def run(self):
         """Execute workflow."""
         self.create_or_restore_agents(self.agent_defs, self.workflow)
-        return self._condition()
+        return await self._condition()
 
     # private methods
     def create_or_restore_agents(self, agent_defs, workflow):
@@ -84,17 +84,22 @@ class Workflow:
             if step.get("name") == name:
                 return steps.index(step)
     
-    def _condition(self):
+    async def _condition(self):
         prompt = self.workflow["spec"]["template"]["prompt"]
         steps = self.workflow["spec"]["template"]["steps"]
         for step in steps:
             if step.get("agent"):
                 step["agent"] = self.agents.get(step["agent"])
+            if step.get("parallel"):
+                agents = []
+                for agent in step.get("parallel"):
+                    agents.append(self.agents.get(agent))
+                step["parallel"] = agents
             self.steps[step["name"]] = Step(step)
         current_step = self.workflow["spec"]["template"]["steps"][0]["name"]
         step_results = {}
         while True:
-            response = self.steps[current_step].run(prompt)
+            response = await self.steps[current_step].run(prompt)
             prompt = response["prompt"]
             if response.get("next"):
                 current_step = response["next"]

--- a/maestro/tests/bee/test_bee.py
+++ b/maestro/tests/bee/test_bee.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os, dotenv, yaml
+import asyncio
 
 from unittest import TestCase
 from pytest_mock import mocker
@@ -29,7 +30,7 @@ class BeeAgentMock:
     def __init__(self):
         pass
 
-    def run(self, prompt: str) -> str:
+    async def run(self, prompt: str) -> str:
         return 'OK:'+prompt
 
 def test_agent_runs(mocker) -> None:
@@ -48,7 +49,7 @@ def test_agent_runs(mocker) -> None:
         workflow = Workflow(agents_yaml, workflow_yaml[0])
     except Exception as excep:
         raise RuntimeError("Unable to create agents") from excep
-    result = workflow.run()
+    result = asyncio.run(workflow.run())
     print(result)
 
     assert result is not None

--- a/maestro/tests/crewai/test_crewai.py
+++ b/maestro/tests/crewai/test_crewai.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import dotenv, os, yaml
+import asyncio
 
 from unittest import TestCase
 
@@ -39,7 +40,7 @@ class CrewAITest(TestCase):
             workflow = Workflow(agents_yaml, workflow_yaml[0])
         except Exception as excep:
             raise RuntimeError("Unable to create agents") from excep
-        result = workflow.run()
+        result = asyncio.run(workflow.run())
         print(result)
 
         assert result is not None

--- a/maestro/tests/examples/test_parallel.py
+++ b/maestro/tests/examples/test_parallel.py
@@ -29,8 +29,8 @@ def parse_yaml(file_path):
     return yaml_data
 
 if __name__ == "__main__":
-    agents_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"condition_agents.yaml"))
-    workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"condition_workflow.yaml"))
+    agents_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/agents/simple_agent.yaml"))
+    workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/workflows/parallel_workflow.yaml"))
     try:
         workflow = Workflow(agents_yaml, workflow_yaml[0])
     except Exception as excep:

--- a/maestro/tests/yamls/agents/simple_agent.yaml
+++ b/maestro/tests/yamls/agents/simple_agent.yaml
@@ -43,3 +43,35 @@ spec:
     - code_interpreter
     - test
   instructions: this is a test.
+
+---
+
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: test4
+  labels:
+    app: test-example
+spec:
+  model: meta-llama/llama-3-1-70b-instruct
+  description: this is a test
+  tools:
+    - code_interpreter
+    - test
+  instructions: this is a test.
+
+---
+
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: test5
+  labels:
+    app: test-example
+spec:
+  model: meta-llama/llama-3-1-70b-instruct
+  description: this is a test
+  tools:
+    - code_interpreter
+    - test
+  instructions: this is a test.

--- a/maestro/tests/yamls/workflows/parallel_workflow.yaml
+++ b/maestro/tests/yamls/workflows/parallel_workflow.yaml
@@ -1,0 +1,31 @@
+apiVersion: maestro/v1
+kind: Workflow
+metadata:
+  name: input_workflow
+  labels:
+    app: input
+spec:
+  template:
+    metadata:
+      name: input_workflow
+      labels:
+        app: example
+        use-case: test
+    agents:
+        - test1
+        - test2
+        - test3
+        - test4
+        - test5
+    prompt: Select a number 1 through 6
+    exception: step4
+    steps:
+      - name: list
+        agent: test1
+      - name: parallel
+        parallel:
+        - test2
+        - test3
+        - test4
+      - name: result
+        agent: test5


### PR DESCRIPTION
Adding **parallel** in step.  The parallel has a list of agent.  The agents are executed in parallel and the step waits until the all agent complete.

Here is the sample workflow yaml file.
```yaml
kind: Workflow
metadata:
  name: input_workflow
  labels:
    app: input
spec:
  template:
    metadata:
      name: input_workflow
      labels:
        app: example
        use-case: test
    agents:
        - test1
        - test2
        - test3
        - test4
        - test5
    prompt: Select a number 1 through 6
    exception: step4
    steps:
      - name: list
        agent: test1
      - name: parallel
        parallel:
        - test2
        - test3
        - test4
      - name: result
        agent: test5

```