### PR TITLE
fix temp directory

### DIFF
--- a/maestro/src/deploy.py
+++ b/maestro/src/deploy.py
@@ -74,7 +74,7 @@ class Deploy:
     def build_image(self, agent, workflow):
         module_path = os.path.abspath(inspect.getsourcefile(lambda:0))
         module_dir = os.path.dirname(module_path)
-        self.tmp_dir = os.path.join(os.getcwd(), "tmp2")
+        self.tmp_dir = os.path.join(tempfile.gettempdir(), "maestro")
         shutil.copytree(os.path.join(module_dir, ".."), self.tmp_dir, dirs_exist_ok=True)
         shutil.copytree(os.path.join(module_dir, "../deployments"), os.path.join(self.tmp_dir, "tmp"), dirs_exist_ok=True)
         shutil.copy(agent, os.path.join(self.tmp_dir, "tmp/agents.yaml"))


### PR DESCRIPTION
Move the temp directory for the deploy to $(tempfile.gettempdir())"/maestro".  My Mac had "TMPDIR" defined.  It was the issue for my case.  

This is from the doc:
```
The directory named by the TMPDIR environment variable.
The directory named by the TEMP environment variable.
The directory named by the TMP environment variable.
A platform-specific location:
On Windows, the directories C:\TEMP, C:\TMP, \TEMP, and \TMP, in that order.
On all other platforms, the directories /tmp, /var/tmp, and /usr/tmp, in that order.
As a last resort, the current working directory.
```