### PR TITLE
drop framework references

### DIFF
--- a/framework/bee-py/README.md
+++ b/framework/bee-py/README.md
@@ -1,3 +1,0 @@
-> COMING SOON
-
-The Python implementation of the Bee Agent Framework is available at: https://github.com/i-am-bee/bee-hive/archive/acc572cb2fe0ca7456662cebb2b324ac45fe3711.zip

--- a/framework/bee-ts/README.md
+++ b/framework/bee-ts/README.md
@@ -1,3 +1,0 @@
-> COMING SOON
-
-The Typescript implementation of the Bee Agent Framework is available at: https://github.com/i-am-bee/bee-agent-framework


### PR DESCRIPTION
Both the python and typescript frameworks can be found at: https://github.com/i-am-bee/beeai-framework