### PR TITLE
add prompt passing feature

### DIFF
--- a/maestro/src/step.py
+++ b/maestro/src/step.py
@@ -65,9 +65,10 @@ class Step:
         return default
 
     def input(self, prompt):
-        user_prompt = self.step_input.get("prompt").replace("{prompt}", str(prompt)) 
-        response = input(user_prompt) 
+        user_prompt = self.step_input.get("prompt").replace("{prompt}", str(prompt))
         template = self.step_input.get("template")
+        if "{CONNECTOR}" in template: return prompt
+        response = input(user_prompt) 
         formatted_response = template.replace("{prompt}", prompt).replace("{response}", response)
         return formatted_response
 


### PR DESCRIPTION
fixes #272 
Currently in the demo, the input keyword basically allows us to kind of "modify the prompt" a bit. In response to this, I've added an additional small feature, which is to pass a specific prompt using the {CONNECTOR} keyword to take advantage of this structure. 

Example usage in the meta agent demo:

agent1: creates the agent yamls necessary for a topic (in this case weather)
input: {CONNECTOR}.  /// because we don't want these files as output, but rather the prompt for the next agent2
agent: create the workflow yaml using what agents are being defined