### PR TITLE
Generalizing agent creation within meta-agents

### DIFF
--- a/maestro/src/agents/meta_agent/README.md
+++ b/maestro/src/agents/meta_agent/README.md
@@ -28,7 +28,7 @@ workflow_schema tool: create by copying the code portion in the agents.yaml file
 
 Note:
 The agents.yaml file currently is generalized, but workflow.yaml needs to specify the agents inside the prompt.
-Specifically, the prompt last prompt of creating the workflow.
+Specifically, the last prompt which creates the workflow.
 
 2 solutions:
 

--- a/maestro/src/agents/meta_agent/README.md
+++ b/maestro/src/agents/meta_agent/README.md
@@ -28,7 +28,7 @@ workflow_schema tool: create by copying the code portion in the agents.yaml file
 
 Note:
 The agents.yaml file currently is generalized, but workflow.yaml needs to specify the agents inside the prompt.
-Specifically, how many agents there are, and what do they do. In the future, this should be able to be generalized.
+Specifically, the prompt last prompt of creating the workflow.
 
 2 solutions:
 

--- a/maestro/src/agents/meta_agent/agents.yaml
+++ b/maestro/src/agents/meta_agent/agents.yaml
@@ -110,3 +110,56 @@ spec:
             except requests.exceptions.RequestException as e:
                 print(f"⚠️ Error fetching schema: {e}")
                 return {"schema": {}}  # Return an empty schema if fetching fails
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: Format Input Agent
+  labels:
+    app: meta-agent
+spec:
+  model: llama3.1
+  description: "Formats a structured prompt by replacing placeholders with user-defined values."
+  instructions: |
+    "You are a **prompt formatter agent**. You are not to actually execute the information within the prompts, but to format, replace placeholders, and output the correct prompt given the template.
+    
+    - Your role is to **replace placeholders** in a structured prompt with user-defined values.
+    - You will receive structured user input specifying:
+      - `N`: The number of agents.
+      - `agent_list`: The names and descriptions of the agents.
+
+    **Template (with placeholders):**
+    ```
+    Build an agents.yaml file using the agent_schema tool as a reference.
+
+    I want N agents, all using the llama3.1 model:
+
+    {agent_list}
+
+    Ensure agents are correctly formatted using the schema.
+    ```
+
+    **Example User Input:**
+    ```
+    number of agents: 2
+    agent1: weather_fetcher – Retrieves weather data for a given location using OpenMeteo.
+    agent2: temperature_comparator – Compares the retrieved temperature with historical averages using OpenMeteo.
+    ```
+
+    **Expected Output:**
+    ```
+    Build an agents.yaml file using the agent_schema tool as a reference.
+
+    I want 2 agents, all using the llama3.1 model:
+
+    weather_fetcher – Retrieves weather data for a given location using OpenMeteo.
+    temperature_comparator – Compares the retrieved temperature with historical averages using OpenMeteo.
+
+    Ensure agents are correctly formatted using the schema.
+    ```
+
+    **Rules:**
+    - Replace `N` with the number of agents.
+    - Replace `{agent_list}` with a **newline-separated list** of agents.
+    - Output the formatted text exactly as structured."

--- a/maestro/src/agents/meta_agent/workflow.yaml
+++ b/maestro/src/agents/meta_agent/workflow.yaml
@@ -11,17 +11,16 @@ spec:
       labels:
         project: maestro-demo
     agents:
+      - Format Input Agent
       - Create Agent YAML
       - Create Workflow YAML
     prompt: |
-            Build an agents.yaml file using the agent_schema tool as a reference.
-
-            I want two agents, both using the llama3.1 model:
-
-            weather_fetcher – Retrieves weather data for a given location using the OpenMeteo tool.
-            temperature_comparator – Compares the retrieved temperature with historical averages using OpenMeteo.
-            Ensure both agents are correctly formatted using the schema.
+            number of agents: 2
+            agent1: weather_fetcher – Retrieves weather data for a given location using OpenMeteo.
+            agent2: temperature_comparator – Compares the retrieved temperature with historical averages using OpenMeteo.
     steps:
+      - name: Format Input
+        agent: Format Input Agent
       - name: Create Agent YAML
         agent: Create Agent YAML
       - name: input


### PR DESCRIPTION
Previously was fixed for weather demo case, but now added another agent which would take in the user prompt for any case, and format it correctly no matter which demo.

Fixes #280, still need to do this for the workflow creation.