### PR TITLE
adding more poetry checks and space handling

### DIFF
--- a/maestro/tools/run-demos.sh
+++ b/maestro/tools/run-demos.sh
@@ -21,22 +21,46 @@ fi
 echo "🔍 Verifying Maestro installation..."
 cd "$REPO_ROOT/maestro"
 
-# Test if maestro works with or without poetry
-if poetry run maestro --help &>/dev/null; then
-    MAESTRO_CMD="poetry run maestro"
-elif maestro --help &>/dev/null; then
+# More robust checking for Maestro
+if command -v poetry &>/dev/null; then
+    echo "Poetry found, checking for maestro..."
+    if poetry run which maestro &>/dev/null; then
+        MAESTRO_CMD="poetry run maestro"
+        echo "✅ Found maestro via poetry"
+    elif poetry run python -m maestro --help &>/dev/null; then
+        MAESTRO_CMD="poetry run python -m maestro"
+        echo "✅ Found maestro module via poetry"
+    else
+        echo "🔄 Installing maestro via poetry..."
+        poetry install
+        if poetry run which maestro &>/dev/null; then
+            MAESTRO_CMD="poetry run maestro"
+            echo "✅ Successfully installed maestro via poetry"
+        else
+            echo "❌ Error: Could not install maestro via poetry"
+            exit 1
+        fi
+    fi
+elif command -v maestro &>/dev/null; then
     MAESTRO_CMD="maestro"
+    echo "✅ Found maestro in PATH"
 else
-    echo "❌ Error: maestro is not running correctly!"
+    echo "❌ Error: Neither poetry nor maestro found in PATH"
+    echo "Please install maestro or poetry first."
     exit 1
 fi
 
 echo "✅ Maestro is running correctly using: $MAESTRO_CMD"
 
-EXPECTED_TESTS=0
-TEST_COUNT=0
+# Create a temporary file to track test counts
+TEMP_DIR=$(mktemp -d)
+EXPECTED_TESTS_FILE="$TEMP_DIR/expected_tests.txt"
+TEST_COUNT_FILE="$TEMP_DIR/test_count.txt"
 
-for demo in $(find "$WORKFLOWS_DIR" -mindepth 1 -type d); do
+echo "0" > "$EXPECTED_TESTS_FILE"
+echo "0" > "$TEST_COUNT_FILE"
+
+find "$WORKFLOWS_DIR" -mindepth 1 -type d -print0 | while IFS= read -r -d '' demo; do
     if [[ "$demo" == "$COMMON_DIR" ]]; then
         echo "⚠️ Skipping common/ directory..."
         continue
@@ -49,19 +73,27 @@ for demo in $(find "$WORKFLOWS_DIR" -mindepth 1 -type d); do
 
     if [[ -f "$demo/agents.yaml" && -f "$demo/workflow.yaml" ]]; then
         echo "🔍 Running tests for $demo"
-        ((EXPECTED_TESTS++))
+        CURRENT_EXPECTED=$(cat "$EXPECTED_TESTS_FILE")
+        echo $((CURRENT_EXPECTED + 1)) > "$EXPECTED_TESTS_FILE"
+        
         echo "🩺 Running common doctor.sh for $demo..."
         cd "$REPO_ROOT/maestro"
-        poetry run bash "$COMMON_DIR/doctor.sh" || { echo "❌ doctor.sh failed for $demo"; exit 1; }
+        bash "$COMMON_DIR/doctor.sh" || { echo "❌ doctor.sh failed for $demo"; exit 1; }
+        
         echo "🧪 Running common test.sh for $demo..."
         cd "$REPO_ROOT/maestro"
-        env MAESTRO_DEMO_OLLAMA_MODEL="ollama/llama3.2:3b" echo "" | poetry run bash "$COMMON_DIR/test.sh" "$demo" || { echo "❌ test.sh failed for $demo"; exit 1; }
-        ((TEST_COUNT++))
+        env MAESTRO_DEMO_OLLAMA_MODEL="ollama/llama3.2:3b" echo "" | bash "$COMMON_DIR/test.sh" "$demo" || { echo "❌ test.sh failed for $demo"; exit 1; }
+    
+        CURRENT_COUNT=$(cat "$TEST_COUNT_FILE")
+        echo $((CURRENT_COUNT + 1)) > "$TEST_COUNT_FILE"
     else
         echo "⚠️ Skipping $demo (no agents.yaml or workflow.yaml found)"
     fi
-
 done
+
+EXPECTED_TESTS=$(cat "$EXPECTED_TESTS_FILE")
+TEST_COUNT=$(cat "$TEST_COUNT_FILE")
+rm -rf "$TEMP_DIR"
 
 if [[ "$TEST_COUNT" -eq "$EXPECTED_TESTS" && "$EXPECTED_TESTS" -gt 0 ]]; then
     echo "✅ All $EXPECTED_TESTS tests completed successfully!"


### PR DESCRIPTION
Fixes #329 

There are two separate issues with the run-demos.sh script:

Issue 1: Spaces in File Paths
When a user has spaces in their file path the script incorrectly splits these paths at spaces, treating each word as a separate directory. Fixed using the null-terminated output format of find with a proper while read loop to preserve spaces

Issue 2: Maestro Not Found
The script can't find the maestro command in certain environments

Fix: Add more robust checking and installation options:
Check if poetry is available
Try multiple ways to find maestro through poetry
Attempt to install via poetry if needed

Try this 
@maximilien 