### PR TITLE
feature: adds mermaid for workflow events (cron)

### DIFF
--- a/maestro/schemas/workflow_schema.json
+++ b/maestro/schemas/workflow_schema.json
@@ -48,16 +48,20 @@
                 }
               }
             },
-            "on": {
+            "event": {
               "type": "object",
               "properties": {
                 "cron": {
                   "type": "string",
                   "description": "The cron job in standard cron format"
                 },
-                "step": {
+                "name": {
                   "type": "string",
-                  "description": "The step name to execute"
+                  "description": "the event name"
+                },
+                "agent": {
+                    "type": "string",
+                    "description": "the agent name to invoke"
                 },
                 "steps": {
                   "type": "array",

--- a/maestro/tests/workflow/test_mermaid.py
+++ b/maestro/tests/workflow/test_mermaid.py
@@ -244,5 +244,95 @@ class TestMermaid_exception(TestCase):
             for m in expected_markdown:
                 self.assertTrue(m in markdown)
 
+class TestMermaid_event_cron(TestCase):
+    def setUp(self):        
+        self.workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/workflows/simple_cron_workflow.yaml"))[0]
+
+    def tearDown(self):
+        self.workflow_yaml = None
+
+    def test_markdown_sequenceDiagram(self):
+        mermaid = Mermaid(self.workflow_yaml, "sequenceDiagram")
+        markdown = mermaid.to_markdown()
+        expected_markdown = [
+            'sequenceDiagram',
+            'participant test1',
+            'participant test2',
+            'participant test3',
+            'participant test4',
+            'test2->>test2: step1',
+            'test2->>test3: step2',
+            'test3->>test1: step3',
+            'test1->>test1: step4',
+            'alt cron "10 14 * * 1"',
+            '  cron->>test4: cron event',
+            'else',
+            '  cron->>exit: ( input.count >= 3 )',
+            'end',
+            'alt exception',
+            '  test2->>test2: step2',
+            '  test2->>test2: step2',
+            '  test3->>test2: step2',
+            '  test1->>test2: step2',
+            'end'
+        ]
+        for m in expected_markdown:
+            self.assertTrue(m in markdown)
+
+    def test_markdown_flowchart(self):
+        for orientation in ["TD", "LR"]:
+            mermaid = Mermaid(self.workflow_yaml, "flowchart", f"{orientation}")
+            self.assertTrue(mermaid.to_markdown().startswith(f"flowchart {orientation}"))
+            markdown = mermaid.to_markdown()
+            expected_markdown = [
+                f"flowchart {orientation}",
+                ]
+            for m in expected_markdown:
+                self.assertTrue(m in markdown)
+
+class TestMermaid_event_cron_many_steps(TestCase):
+    def setUp(self):
+        self.workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/workflows/simple_cron_many_steps_workflow.yaml"))[0]
+
+    def tearDown(self):
+        self.workflow_yaml = None
+
+    def test_markdown_sequenceDiagram(self):
+        mermaid = Mermaid(self.workflow_yaml, "sequenceDiagram")
+        markdown = mermaid.to_markdown()
+        expected_markdown = [
+            'sequenceDiagram',
+            'participant test1',
+            'participant test2',
+            'participant test3',
+            'test2->>test2: step1',
+            'test2->>test3: step2',
+            'test3->>test3: step3',
+            'alt cron "10 14 * * 1"',
+            '  cron->>test2: step2',
+            '  cron->>test3: step3',
+            'else',
+            '  cron->>exit: ( input.exit == True )',
+            'end',
+            'alt exception',
+            '  test2->>test2: step2',
+            '  test2->>test2: step2',
+            '  test3->>test2: step2',
+            'end'
+        ]
+        for m in expected_markdown:
+            self.assertTrue(m in markdown)
+
+    def test_markdown_flowchart(self):
+        for orientation in ["TD", "LR"]:
+            mermaid = Mermaid(self.workflow_yaml, "flowchart", f"{orientation}")
+            self.assertTrue(mermaid.to_markdown().startswith(f"flowchart {orientation}"))
+            markdown = mermaid.to_markdown()
+            expected_markdown = [
+                f"flowchart {orientation}",
+                ]
+            for m in expected_markdown:
+                self.assertTrue(m in markdown)
+
 if __name__ == '__main__':
     unittest.main()

--- a/maestro/tests/yamls/workflows/simple_cron_many_steps_workflow.yaml
+++ b/maestro/tests/yamls/workflows/simple_cron_many_steps_workflow.yaml
@@ -11,8 +11,9 @@ spec:
       labels:
         app: cron
         use-case: test
-    on:
+    event:
        cron: "10 14 * * 1"
+       name: multi step cron
        steps:
          - step2
          - step3

--- a/maestro/tests/yamls/workflows/simple_cron_workflow.yaml
+++ b/maestro/tests/yamls/workflows/simple_cron_workflow.yaml
@@ -11,14 +11,16 @@ spec:
       labels:
         app: cron
         use-case: test
-    on:
+    event:
        cron: "10 14 * * 1"
-       step: step1
+       name: cron event
+       agent: test4
        exit: ( input.count >= 3 )
     agents:
         - test1
         - test2
         - test3
+        - test4
     prompt: This is a test input
     exception:
         name: step2
@@ -30,3 +32,5 @@ spec:
         agent: test2
       - name: step3
         agent: test3
+      - name: step4
+        agent: test1


### PR DESCRIPTION
When merged this will complete the `event` subtask of issue #297 

Change highlights:

* changed workflow schema to use `event` instead of `on` which is reserved word for JSON/JavaScript (I think)
* changed `event` schema to take `name` and alternatively `agent` or `steps` for multi-steps event handling
* small refactor of `Workflow` class to add methods for fixing agent names and finding agent for a step
* added ``__to_sequenceDiagram_event to generate sequenceDiagram mermaid for event 

TODO: complete `__to_flowchart_event` to generate sequenceDiagram mermaid for event 

As example, for workflow YAML:

```yaml
apiVersion: maestro/v1
kind: Workflow
metadata:
  name: simple cron workflow
  labels:
    app: cron-example    
spec:
  template:
    metadata:
      name: cron-example
      labels:
        app: cron
        use-case: test
    event:
       cron: "10 14 * * 1"
       name: cron event
       agent: test4
       exit: ( input.count >= 3 )
    agents:
        - test1
        - test2
        - test3
        - test4
    prompt: This is a test input
    exception:
        name: step2
        agent: test2
    steps:
      - name: step1
        agent: test2
      - name: step2
        agent: test2
      - name: step3
        agent: test3
      - name: step4
        agent: test1
```

generating mermaid sequence diagram:

```mermaid
sequenceDiagram
participant test1
participant test2
participant test3
participant test4
test2->>test2: step1
test2->>test3: step2
test3->>test1: step3
test1->>test1: step4
alt cron "10 14 * * 1"
  cron->>test4: cron event
else
  cron->>exit: ( input.count >= 3 )
end
alt exception
  test2->>test2: step2
  test2->>test2: step2
  test3->>test2: step2
  test1->>test2: step2
end
```

And  for workflow YAML:

```yaml
apiVersion: maestro/v1
kind: Workflow
metadata:
  name: simple cron workflow
  labels:
    app: cron-example    
spec:
  template:
    metadata:
      name: cron-example
      labels:
        app: cron
        use-case: test
    event:
       cron: "10 14 * * 1"
       name: multi step cron
       steps:
         - step2
         - step3
       exit: ( input.exit == True )
    agents:
        - test1
        - test2
        - test3
    prompt: This is a test input
    exception:
        name: step2
        agent: test2
    steps:
      - name: step1
        agent: test2
      - name: step2
        agent: test2
      - name: step3
        agent: test3
```

generating mermaid sequence diagram:

```mermaid
sequenceDiagram
participant test1
participant test2
participant test3
test2->>test2: step1
test2->>test3: step2
test3->>test3: step3
alt cron "10 14 * * 1"
  cron->>test2: step2
  cron->>test3: step3
else
  cron->>exit: ( input.exit == True )
end
alt exception
  test2->>test2: step2
  test2->>test2: step2
  test3->>test2: step2
end
```