### PR TITLE
fixed newline error

### DIFF
--- a/maestro/deployments/api.py
+++ b/maestro/deployments/api.py
@@ -27,9 +27,10 @@ def generate():
     global thread
     message = output.getvalue()
     if len(message) > position:
-        text = "data: " + output.getvalue()[position:].replace("\n", "  \ndata: ")+ "\n\n"
-        yield text
-    position = len(message)
+        lines = output.getvalue()[position:].splitlines()
+        for line in lines:
+            yield f"data: {line}\n\n"
+        position = len(message)
     #if thread and not thread.is_alive():
     #    text = "data: Thread completed EndEnd\n\n"
     #    yield text


### PR DESCRIPTION
closes #339 

Previous code is replacing \n with \ndata: (which is markdown line break + next data prefix), but it's putting it all in one yield, which causes multiple lines to be appended as one message