### PR TITLE
feature: adds parallel sequenceDiagram

### DIFF
--- a/maestro/src/mermaid.py
+++ b/maestro/src/mermaid.py
@@ -80,6 +80,9 @@ class Mermaid:
             if step.get('condition'):
                 for condition in step['condition']:
                     sb += self.__to_sequenceDiagram_condition(agentL, agentR, condition)
+            # if step has parallel execution
+            if step.get('parallel'):
+                sb += self.__to_sequenceDiagram_parallel(agentL, step)
             i = i + 1
         # if workflow has global on event handling
         if self.workflow['spec']['template'].get('event'):
@@ -103,6 +106,19 @@ class Mermaid:
             sb += f"  cron->>{agent}: {name}\n"
         sb += "else\n"
         sb += f"  cron->>exit: {exit}\n"
+        sb += 'end\n'
+        return sb
+
+    # convert parallel to mermaid sequenceDiagram
+    def __to_sequenceDiagram_parallel(self, agentL, parallelStep):
+        i, sb = 0, 'par\n'
+        agents = parallelStep['parallel']
+        for agent in agents:
+            agentR = self.__fix_agent_name(agent)
+            sb += f"  {agentL}->>{agentR}: {parallelStep['name']}\n"
+            if i < len(agents):
+                sb += 'and\n'
+            i += 1
         sb += 'end\n'
         return sb
 

--- a/maestro/tests/workflow/test_mermaid.py
+++ b/maestro/tests/workflow/test_mermaid.py
@@ -334,5 +334,50 @@ class TestMermaid_event_cron_many_steps(TestCase):
             for m in expected_markdown:
                 self.assertTrue(m in markdown)
 
+class TestMermaid_parallel(TestCase):
+    def setUp(self):        
+        self.workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/workflows/parallel_workflow.yaml"))[0]
+
+    def tearDown(self):
+        self.workflow_yaml = None
+
+    def test_markdown_sequenceDiagram(self):
+        mermaid = Mermaid(self.workflow_yaml, "sequenceDiagram")
+        markdown = mermaid.to_markdown()
+        expected_markdown = [
+            'sequenceDiagram',
+            'participant test1',
+            'participant test2',
+            'participant test3',
+            'participant test4',
+            'participant test5',
+            'test1->>test1: list',
+            'test1->>test5: parallel',
+            'test5->>test5: result',
+            'par',
+            '  test1->>test2: parallel',
+            'and',
+            '  test1->>test3: parallel',
+            'and',
+            '  test1->>test4: parallel',
+            'end',
+            'alt exception',
+            '  test1->>test4: step4',
+            '  test5->>test4: step4',
+            'end']
+        for m in expected_markdown:
+            self.assertTrue(m in markdown)
+
+    def test_markdown_flowchart(self):
+        for orientation in ["TD", "LR"]:
+            mermaid = Mermaid(self.workflow_yaml, "flowchart", f"{orientation}")
+            self.assertTrue(mermaid.to_markdown().startswith(f"flowchart {orientation}"))
+            markdown = mermaid.to_markdown()
+            expected_markdown = [
+                f"flowchart {orientation}",
+                ]
+            for m in expected_markdown:
+                self.assertTrue(m in markdown)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When merged this will solve parts of the `parallel` subtask of issue #297.

This PR includes the sequenceDiagram. So for a workflow as:

```yaml
apiVersion: maestro/v1
kind: Workflow
metadata:
  name: input_workflow
  labels:
    app: input
spec:
  template:
    metadata:
      name: input_workflow
      labels:
        app: example
        use-case: test
    agents:
        - test1
        - test2
        - test3
        - test4
        - test5
    prompt: Select a number 1 through 6
    exception:
        name: step4
        agent: test4
    steps:
      - name: list
        agent: test1
      - name: parallel
        parallel:
        - test2
        - test3
        - test4
      - name: result
        agent: test5
```

This will generate mermaid:

```mermaid
sequenceDiagram
participant test1
participant test2
participant test3
participant test4
participant test5
test1->>test1: list
test1->>test5: parallel
par
  test1->>test2: parallel
and
  test1->>test3: parallel
and
  test1->>test4: parallel
and
end
test5->>test5: result
alt exception
  test1->>test4: step4
  test5->>test4: step4
end
```

I will work on generating flowchart as separate PR. So @george-lhj review and give me LGTM if OK.