### PR TITLE
feature: Issue #297 loop sequenceDiagram

### DIFF
--- a/maestro/src/mermaid.py
+++ b/maestro/src/mermaid.py
@@ -83,6 +83,9 @@ class Mermaid:
             # if step has parallel execution
             if step.get('parallel'):
                 sb += self.__to_sequenceDiagram_parallel(agentL, step)
+            # if step has loop
+            if step.get('loop'):
+                sb += self.__to_sequenceDiagram_loop(agentL, step['loop'])
             i = i + 1
         # if workflow has global on event handling
         if self.workflow['spec']['template'].get('event'):
@@ -131,6 +134,19 @@ class Mermaid:
                 sb += f"  {agentL}->>{exception['agent']}: {exception['name']}\n"
             i += 1
         sb += 'end'
+        return sb
+
+    # convert loop to mermaid sequenceDiagram
+    def __to_sequenceDiagram_loop(self, agentL, loopStep):
+        i, sb = 0, ''
+        agentR = self.__fix_agent_name(loopStep['agent'])
+        loop_name, loop_expr = 'loop', 'True'
+        if loopStep.get('until'):
+            loop_name = 'until'
+            loop_expr = loopStep['until']
+        sb += f"loop {loop_expr}\n"
+        sb += f"  {agentL}-->{agentR}: {loop_name}\n"
+        sb += 'end\n'
         return sb
 
     # convert condition section to sequenceDiagram mermaid diagram

--- a/maestro/tests/workflow/test_mermaid.py
+++ b/maestro/tests/workflow/test_mermaid.py
@@ -286,6 +286,7 @@ class TestMermaid_event_cron(TestCase):
             markdown = mermaid.to_markdown()
             expected_markdown = [
                 f"flowchart {orientation}",
+                #TODO complete
                 ]
             for m in expected_markdown:
                 self.assertTrue(m in markdown)
@@ -330,6 +331,7 @@ class TestMermaid_event_cron_many_steps(TestCase):
             markdown = mermaid.to_markdown()
             expected_markdown = [
                 f"flowchart {orientation}",
+                #TODO: complete
                 ]
             for m in expected_markdown:
                 self.assertTrue(m in markdown)
@@ -375,6 +377,42 @@ class TestMermaid_parallel(TestCase):
             markdown = mermaid.to_markdown()
             expected_markdown = [
                 f"flowchart {orientation}",
+                #TODO: complete
+                ]
+            for m in expected_markdown:
+                self.assertTrue(m in markdown)
+
+class TestMermaid_loop(TestCase):
+    def setUp(self):        
+        self.workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/workflows/parallel_workflow.yaml"))[0]
+
+    def tearDown(self):
+        self.workflow_yaml = None
+
+    def test_markdown_sequenceDiagram(self):
+        mermaid = Mermaid(self.workflow_yaml, "sequenceDiagram")
+        markdown = mermaid.to_markdown()
+        expected_markdown = [
+            'sequenceDiagram',
+            'participant generate1_10',
+            'participant countdown',
+            'generate1_10->>generate1_10: step1',
+            'generate1_10->>countdown:step2',
+            'loop (input.find("happy") != -1)',
+            '  step2-->countdown: until',
+            'end'
+            ]
+        for m in expected_markdown:
+            self.assertTrue(m in markdown)
+
+    def test_markdown_flowchart(self):
+        for orientation in ["TD", "LR"]:
+            mermaid = Mermaid(self.workflow_yaml, "flowchart", f"{orientation}")
+            self.assertTrue(mermaid.to_markdown().startswith(f"flowchart {orientation}"))
+            markdown = mermaid.to_markdown()
+            expected_markdown = [
+                f"flowchart {orientation}",
+                #TODO: complete
                 ]
             for m in expected_markdown:
                 self.assertTrue(m in markdown)

--- a/maestro/tests/workflow/test_mermaid.py
+++ b/maestro/tests/workflow/test_mermaid.py
@@ -384,7 +384,7 @@ class TestMermaid_parallel(TestCase):
 
 class TestMermaid_loop(TestCase):
     def setUp(self):        
-        self.workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/workflows/parallel_workflow.yaml"))[0]
+        self.workflow_yaml = parse_yaml(os.path.join(os.path.dirname(__file__),"../yamls/workflows/loop_workflow.yaml"))[0]
 
     def tearDown(self):
         self.workflow_yaml = None
@@ -397,9 +397,9 @@ class TestMermaid_loop(TestCase):
             'participant generate1_10',
             'participant countdown',
             'generate1_10->>generate1_10: step1',
-            'generate1_10->>countdown:step2',
+            'generate1_10->>generate1_10: step2',
             'loop (input.find("happy") != -1)',
-            '  step2-->countdown: until',
+            '  generate1_10-->countdown: until',
             'end'
             ]
         for m in expected_markdown:


### PR DESCRIPTION
When merged this will solve the `parallel` subtask of issue #297.

This PR includes the sequenceDiagram. So for a workflow as:

```yaml
apiVersion: maestro/v1
kind: Workflow
metadata:
  name: loop workflow
  labels:
    app: example
spec:
  strategy:
    type: sequence
  template:
    metadata:
      name: loop-workflow
      labels:
        app: example
        use-case: test
    agents:
        - generate1-10
        - countdown
    prompt: Generate a number
    steps:
      - name: step1
        agent: generate1-10
      - name: step2
        loop: 
            agent: countdown
            until: (input.find("happy") != -1)

```

This will generate mermaid:

```mermaid
sequenceDiagram
participant generate1_10
participant countdown
generate1_10->>generate1_10: step1
generate1_10->>generate1_10: step2
loop (input.find("happy") != -1)
  generate1_10-->countdown: until
end
```

I will work on generating flowchart as separate PR. So @george-lhj review and give me LGTM if OK.