### PR TITLE
fixing default prompt issue

### DIFF
--- a/maestro/cli/commands.py
+++ b/maestro/cli/commands.py
@@ -270,7 +270,6 @@ class DeployCmd(Command):
 
     def deploy(self):
         try:
-            
             self.__deploy_agents_workflow(self.AGENTS_FILE(), self.WORKFLOW_FILE(), self.ENV())
         except Exception as e:
             self._check_verbose()

--- a/maestro/cli/commands.py
+++ b/maestro/cli/commands.py
@@ -217,6 +217,9 @@ class DeployCmd(Command):
     def __init__(self, args):
         self.args = args
         super().__init__(self.args)
+
+    def auto_prompt(self):
+        return self.args.get('--auto-prompt', False)
     
     def __deploy_agents_workflow(self, agents_yaml, workflow_yaml, env):
         try:
@@ -257,19 +260,24 @@ class DeployCmd(Command):
         return self.args['WORKFLOW_FILE']
 
     def ENV(self):
-        return " ".join(self.args['ENV'])
+        env_vars = self.args['ENV']
+        if self.auto_prompt():
+            env_vars.append("AUTO_RUN=true")
+        return " ".join(env_vars)
 
     def name(self):
       return "deploy"
 
     def deploy(self):
         try:
+            
             self.__deploy_agents_workflow(self.AGENTS_FILE(), self.WORKFLOW_FILE(), self.ENV())
         except Exception as e:
             self._check_verbose()
             Console.error(f"Unable to deploy workflow: {str(e)}")
             return 1
         return 0
+        
 
 # Mermaid command group
 # $ maestro mermaid WORKFLOW_FILE [options]

--- a/maestro/cli/maestro.py
+++ b/maestro/cli/maestro.py
@@ -30,6 +30,7 @@ Options:
   --verbose              Show all output.
   --silent               Show no additional output on success, e.g., no OK or Success etc
   --dry-run              Mocks agents and other parts of workflow execution.
+  --auto-prompt
 
   --url                  The deployment URL, default: 127.0.0.1:5000
   --k8s                  Deploys to Kubernetes

--- a/maestro/cli/maestro.py
+++ b/maestro/cli/maestro.py
@@ -30,7 +30,7 @@ Options:
   --verbose              Show all output.
   --silent               Show no additional output on success, e.g., no OK or Success etc
   --dry-run              Mocks agents and other parts of workflow execution.
-  --auto-prompt
+  --auto-prompt          Run prompt by default if specified
 
   --url                  The deployment URL, default: 127.0.0.1:5000
   --k8s                  Deploys to Kubernetes

--- a/maestro/deployments/api.py
+++ b/maestro/deployments/api.py
@@ -55,24 +55,24 @@ def process_workflow():
         agents_yaml = parse_yaml("src/agents.yaml")
         workflow_yaml = parse_yaml("src/workflow.yaml")
         prompt = request.args.get("Prompt")
+        auto_run = os.getenv("AUTO_RUN", "false").lower() == "true"
+        should_run = auto_run or prompt
         if prompt:
             workflow_yaml[0]["spec"]["template"]["prompt"] = prompt
         try:
             workflow_instance = Workflow(agents_yaml, workflow_yaml[0])
         except Exception as excep:
             raise RuntimeError("Unable to create agents") from excep
-
         diagram = workflow_instance.to_mermaid()
-
-        clear = request.args.get("Clear Output")
-        if clear:
-            output = io.StringIO()
-        position = 0
-        thread = threading.Thread(target=start_workflow)
-        thread.start()
-
-        name = workflow_yaml[0]["metadata"]["name"]
-        return render_template('index.html', result="", title=name, diagram=diagram)
+        if should_run:
+            clear = request.args.get("Clear Output")
+            if clear:
+                output = io.StringIO()
+            position = 0
+            thread = threading.Thread(target=start_workflow)
+            thread.start()
+    name = workflow_yaml[0]["metadata"]["name"]
+    return render_template('index.html', result="", title=name, diagram=diagram)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0')

--- a/maestro/tests/cli/test_commands.py
+++ b/maestro/tests/cli/test_commands.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import os
-
+import unittest
 from unittest import TestCase
 
 from cli.commands import CLI

--- a/maestro/tests/cli/test_commands.py
+++ b/maestro/tests/cli/test_commands.py
@@ -78,21 +78,42 @@ class DeployCommand(TestCommand):
         self.assertTrue(self.command.execute() == 0)
 
     def test_deploy_without_auto_prompt(self):
-        self.args.pop('--auto_prompt', None)
+        import tempfile, yaml
+
+        # Create a temporary workflow file with the expected nested structure.
+        dummy_workflow = {
+            "spec": {
+                "template": {
+                    "prompt": "This is a test input"
+                }
+            }
+        }
+        temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.yaml')
+        yaml.safe_dump(dummy_workflow, temp_file)
+        temp_file.close()
+
+        # Set up the CLI arguments to use this temporary file.
+        self.args["WORKFLOW_FILE"] = temp_file.name
+        self.args.pop("--auto_prompt", None)  # Ensure auto prompt is NOT set.
         self.args["--docker"] = True
         self.command = CLI(self.args).command()
 
-        import yaml
+        # Monkey-patch the deploy helper to capture the processed workflow YAML.
         def dummy_deploy(self, agents_yaml, workflow_file, env):
             with open(workflow_file, 'r') as f:
                 docs = list(yaml.safe_load_all(f))
             self.captured_workflow = docs[0]
             return 0
         self.command._DeployCmd__deploy_agents_workflow = dummy_deploy.__get__(self.command, type(self.command))
+
+        # Execute the command.
         self.command.execute()
+
+        # Check that the prompt field has been removed from the nested template.
         template = self.command.captured_workflow.get("spec", {}).get("template", {})
         self.assertNotIn("prompt", template, "Prompt field should be removed when --auto_prompt is not set")
 
+        
 # `run` commmand tests
 class RunCommand(TestCommand):
     def setUp(self):


### PR DESCRIPTION
fixes #332 
added new --auto-prompt flag to the maestro deploy command. When present, the deployed Maestro UI will automatically start the workflow using the prompt specified in the YAML file.

By default upon load, we will need to wait for the user to enter the prompt if the flag is not added

Added --auto-prompt flag to maestro deploy CLI definition (maestro.py, commands.py)
Set AUTO_RUN=true as an environment variable if --auto-prompt is used
Updated api.py to conditionally run the workflow on page load if AUTO_RUN is set or a prompt is manually submitted

added test