### PR TITLE
Bug: using json serialization instead of fstrings to prevent newline errors

### DIFF
--- a/maestro/src/agents/bee_agent.py
+++ b/maestro/src/agents/bee_agent.py
@@ -4,7 +4,7 @@
 import os, dotenv
 import asyncio
 import requests
-
+import json
 from openai import AssistantEventHandler, OpenAI
 from openai.types.beta import AssistantStreamEvent
 from openai.types.beta.threads.runs import RunStep, RunStepDelta, ToolCall
@@ -28,7 +28,22 @@ class BeeAgent(Agent):
         super().__init__(agent)
     
         url = f'{os.getenv("BEE_API")}/v1/assistants'
-        payload = f'{{"tools": [{{"type": "code_interpreter"}},{{"type": "system","system": {{"id": "web_search"}}}},{{"type": "system","system": {{"id": "weather"}}}}],"name": "{self.agent_name}","description": "{self.agent_desc}","instructions": "{self.instructions}","metadata": {{}},"model": "{self.agent_model}","agent": "bee","top_p": 1,"temperature": 0.1}}'
+        payload_dict = {
+            "tools": [
+                {"type": "code_interpreter"},
+                {"type": "system", "system": {"id": "web_search"}},
+                {"type": "system", "system": {"id": "weather"}}
+            ],
+            "name": self.agent_name,
+            "description": self.agent_desc,
+            "instructions": self.instructions.strip(),
+            "metadata": {},
+            "model": self.agent_model,
+            "agent": "bee",
+            "top_p": 0.8,
+            "temperature": 0.1
+        }
+        payload = json.dumps(payload_dict)
         headers = {
             'accept': "application/json",
             'Authorization': "Bearer sk-proj-testkey",


### PR DESCRIPTION
fixes #370 

The agent creation fails with a KeyError for "id" because the multi-line instructions (using a plain vertical bar) retained an extra newline. This extra newline caused the manually constructed JSON payload to be malformed, resulting in an unexpected response from the API.


Switched from manually building the JSON string using an f-string to constructing a Python dictionary and serializing it with json.dumps. This ensures all special characters and newlines in fields like "instructions" are properly escaped.
Optionally, applied .strip() to the instructions value to remove any unwanted leading/trailing whitespace.

Also changed the top_p (which is the probability distribtion param) to be 0.8 instead of 1; since we want more deterministic answers