### PR TITLE
feature: first version of meta-agents streamlit UI/UX

### DIFF
--- a/maestro/cli/commands.py
+++ b/maestro/cli/commands.py
@@ -23,7 +23,7 @@ from jsonschema.exceptions import ValidationError, SchemaError
 
 from src.deploy import Deploy
 from src.workflow import Workflow, create_agents
-from cli.common import Console, parse_yaml
+from cli.common import Console, parse_yaml, read_file
 from cli.streamlit_deploy import deploy_agents_workflow_streamlit
 
 # Root CLI class
@@ -49,6 +49,8 @@ class CLI:
             return DeployCmd(self.args)
         elif self.args.get('mermaid') and self.args['mermaid']:
             return MermaidCmd(self.args)
+        elif self.args.get('meta-agents') and self.args['meta-agents']:
+            return MetaAgentsCmd(self.args)
         else:
             raise Exception("Invalid command")
 
@@ -107,6 +109,8 @@ class Command:
             return self.deploy
         elif self.args['mermaid']:
             return self.mermaid
+        elif self.args['meta-agents']:
+            return self.meta_agents
         else:
             raise Exception("Invalid subcommand")
 
@@ -345,5 +349,41 @@ class MermaidCmd(Command):
         except Exception as e:
             self._check_verbose()
             Console.error(f"Unable to generate mermaid for workflow: {str(e)}")
+            return 1
+        return 0
+
+# MetaAgents command group
+# $ maestro meta-agents TEXT_FILE [options]
+class MetaAgentsCmd(Command):
+    def __init__(self, args):
+        self.args = args
+        super().__init__(self.args)
+
+    # private    
+    def __meta_agents(self, text_file) -> int:
+        try:
+            sys.argv = ["streamlit", "run", "./cli/streamlit_meta_agents_deploy.py", text_file]
+            process = Popen(sys.argv)
+        except Exception as e:
+            self._check_verbose()
+            raise RuntimeError(f"{str(e)}") from e
+        return 0
+
+    # public options
+    def TEXT_FILE(self):
+        return self.args.get('TEXT_FILE')
+
+    def name(self):
+      return "meta-agents"
+
+    # public command method
+    def meta_agents(self):
+        try:
+            rc = self.__meta_agents(self.TEXT_FILE())
+            if not self.silent():
+                Console.ok("Running meta-agents\n")
+        except Exception as e:
+            self._check_verbose()
+            Console.error(f"Unable to run meta-agents: {str(e)}")
             return 1
         return 0

--- a/maestro/cli/maestro.py
+++ b/maestro/cli/maestro.py
@@ -22,6 +22,7 @@ Usage:
   maestro mermaid WORKFLOW_FILE [options]
   maestro run AGENTS_FILE WORKFLOW_FILE [options]
   maestro validate SCHEMA_FILE YAML_FILE [options]
+  maestro meta-agents TEXT_FILE [options]
 
   maestro (-h | --help)
   maestro (-v | --version)

--- a/maestro/cli/streamlit_deploy.py
+++ b/maestro/cli/streamlit_deploy.py
@@ -53,8 +53,10 @@ def deploy_agents_workflow_streamlit(agents_file, workflow_file):
     # Initialize session state for chat history
     if "messages" not in st.session_state:
         st.session_state.messages = [
-            {"role": "assistant", "content": "Welcome to Maestro workflow?"}
-        ]
+            { 
+                "role": "assistant", 
+                "content": "Welcome to Maestro workflow"
+            }]
 
     # Page header
     st.image("images/maestro.png", width=200)

--- a/maestro/cli/streamlit_meta_agents_deploy.py
+++ b/maestro/cli/streamlit_meta_agents_deploy.py
@@ -39,12 +39,12 @@ def deploy_meta_agents_streamlit(prompt_text_file):
 
     with agents_tab:
         st.header("Meta-agents 🤖 -> agents.yaml")
-        ma_agents_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', title="Maestro meta-agents agents workflow")
+        ma_agents_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', prompt, 'Maestro meta-agents agents workflow')
         ma_agents_workflow_ui.setup_ui()
     
     with workflow_tab:
         st.header("Meta-agents 🤖 -> workflow.yaml")
-        ma_workflow_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', title="Maestro meta-agents workflow")        
+        ma_workflow_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', prompt, 'Maestro meta-agents workflow')
         ma_workflow_workflow_ui.setup_ui()
 
     with generated_workflow_tab:

--- a/maestro/cli/streamlit_meta_agents_deploy.py
+++ b/maestro/cli/streamlit_meta_agents_deploy.py
@@ -49,8 +49,12 @@ def deploy_meta_agents_streamlit(prompt_text_file):
 
     with generated_workflow_tab:
         st.header("Meta-agents generated ⌇ -> Workflow")
-        # TODO: Add UI for meta-agents agents workflow        
+        agent_file = st.file_uploader("Choose agents.yaml", key='agents.yaml')
+        workflow_file = st.file_uploader("Choose agents.yaml", key='workflow.yaml')
 
+        if agent_file is not None and workflow_file is not None:
+            ma_gent_workflow_workflow_ui = StreamlitWorkflowUI(agent_file.getvalue().decode("utf-8"), workflow_file.getvalue().decode("utf-8"), '', 'Maestro meta-agents generated workflow')
+            ma_gent_workflow_workflow_ui.setup_ui()
 
 if __name__ == '__main__':
     if runtime.exists():

--- a/maestro/cli/streamlit_meta_agents_deploy.py
+++ b/maestro/cli/streamlit_meta_agents_deploy.py
@@ -27,7 +27,7 @@ def deploy_meta_agents_streamlit(prompt_text_file):
     # Initialize session state for chat history
     if "messages" not in st.session_state:
         st.session_state.messages = [
-            {"role": "assistant", "content": "Welcome to Maestro meta-agents workflow?"}
+            {"role": "assistant", "content": "Welcome to Maestro meta-agents workflow"}
         ]
 
     # Page header

--- a/maestro/cli/streamlit_meta_agents_deploy.py
+++ b/maestro/cli/streamlit_meta_agents_deploy.py
@@ -1,0 +1,61 @@
+import os, sys, traceback, psutil
+
+import streamlit as st
+import streamlit.web.cli as st_cli
+
+from streamlit import runtime
+from streamlit.runtime.scriptrunner import add_script_run_ctx,get_script_run_ctx
+
+from streamlit_workflow_ui import StreamlitWorkflowUI
+
+from cli.common import Console, parse_yaml, read_file
+
+def deploy_meta_agents_streamlit(prompt_text_file):
+    prompt = "Enter your maestro meta-agents prompt here"
+    try:
+        prompt = read_file(prompt_text_file)
+    except Exception as e:
+        Console.error(f"Unable to read prompt text file: {prompt_text_file} error: {str(e)}")
+
+    # Set page configuration
+    st.set_page_config(
+        page_title="Maestro Meta-Agents Workflow",
+        page_icon="🤖",
+        layout="centered"
+    )
+
+    # Initialize session state for chat history
+    if "messages" not in st.session_state:
+        st.session_state.messages = [
+            {"role": "assistant", "content": "Welcome to Maestro meta-agents workflow?"}
+        ]
+
+    # Page header
+    st.image("images/maestro.png", width=200)
+    st.title(f"Maestro Meta-Agents workflows")
+
+    # Set tabs for: Meta-Agents agents and workflow workflows and the generated workflow
+    agents_tab, workflow_tab, generated_workflow_tab = st.tabs(["Agents", "Workflow", "Generated"])
+
+    with agents_tab:
+        st.header("Meta-agents 🤖 -> agents.yaml")
+        ma_agents_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', title="Maestro meta-agents agents workflow")
+        ma_agents_workflow_ui.setup_ui()
+    
+    with workflow_tab:
+        st.header("Meta-agents 🤖 -> workflow.yaml")
+        ma_workflow_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', title="Maestro meta-agents workflow")        
+        ma_workflow_workflow_ui.setup_ui()
+
+    with generated_workflow_tab:
+        st.header("Meta-agents generated ⌇ -> Workflow")
+        # TODO: Add UI for meta-agents agents workflow        
+
+
+if __name__ == '__main__':
+    if runtime.exists():
+        ctx = get_script_run_ctx()
+        deploy_meta_agents_streamlit(sys.argv[1])
+        add_script_run_ctx(psutil.Process(os.getpid()), ctx)
+    else:
+        sys.exit(st_cli.main())

--- a/maestro/cli/streamlit_workflow_ui.py
+++ b/maestro/cli/streamlit_workflow_ui.py
@@ -11,8 +11,9 @@ sys_stdout = sys.stdout
 global workflow_instance
 
 class StreamlitWorkflowUI:
-    def __init__(self, agents_file, workflow_file, title="Maestro workflow"):
+    def __init__(self, agents_file, workflow_file, prompt, title="Maestro workflow"):
         self.title = title
+        self.prompt = prompt
         self.agents_file = agents_file
         self.workflow_file = workflow_file
 
@@ -24,6 +25,7 @@ class StreamlitWorkflowUI:
         self.__initialize_session_state()
         self.__add_workflow_name_and_files()
         self.__create_workflow_ui()
+        self.__add_initial_prompt()
         self.__create_chat_messages()
         self.__create_chat_input()
         self.__add__chat_reset_button()
@@ -42,6 +44,10 @@ class StreamlitWorkflowUI:
             with st.popover("workflow.yaml"):
                 st.markdown("## Formatted workflow YAML")
                 st.code(read_file(self.workflow_file), language="yaml", line_numbers=True, wrap_lines=False, height=700)
+
+    def __add_initial_prompt(self):
+        # add text area with initial input text prompt
+        st.text_area("Initial prompt", self.prompt, key=f"text_area:{self.title}")
 
     def __initialize_session_state(self):
         # Initialize session state for chat history

--- a/maestro/cli/streamlit_workflow_ui.py
+++ b/maestro/cli/streamlit_workflow_ui.py
@@ -11,7 +11,7 @@ sys_stdout = sys.stdout
 global workflow_instance
 
 class StreamlitWorkflowUI:
-    def __init__(self, agents_file, workflow_file, prompt, title="Maestro workflow"):
+    def __init__(self, agents_file, workflow_file, prompt='', title='Maestro workflow'):
         self.title = title
         self.prompt = prompt
         self.agents_file = agents_file

--- a/maestro/cli/streamlit_workflow_ui.py
+++ b/maestro/cli/streamlit_workflow_ui.py
@@ -47,6 +47,8 @@ class StreamlitWorkflowUI:
 
     def __add_initial_prompt(self):
         # add text area with initial input text prompt
+        if self.prompt == "":
+            self.prompt = f"{self.workflow_yaml[0]['spec']['template']['prompt']}"
         st.text_area("Initial prompt", self.prompt, key=f"text_area:{self.title}")
 
     def __initialize_session_state(self):
@@ -68,7 +70,7 @@ class StreamlitWorkflowUI:
         st.button('Reset', on_click=reset_conversation, key=f"reset_button:{self.title}")
 
     def __create_chat_input(self):
-        prompt = st.chat_input(f"{self.workflow_yaml[0]['spec']['template']['prompt']}", key=f"chat_input:{self.title}")
+        prompt = st.chat_input('Execute initial prompt or enter new prompt', key=f"chat_input:{self.title}")
         if prompt:
             # Add user message to chat history
             st.session_state.messages.append({"role": "user", "content": prompt})

--- a/maestro/cli/streamlit_workflow_ui.py
+++ b/maestro/cli/streamlit_workflow_ui.py
@@ -1,0 +1,141 @@
+import io, sys, asyncio, subprocess, os, psutil, traceback
+
+import streamlit as st
+import streamlit_mermaid as stmd
+
+from src.workflow import Workflow
+from cli.common import Console, parse_yaml, read_file
+
+sys_stdout = sys.stdout
+
+global workflow_instance
+
+class StreamlitWorkflowUI:
+    def __init__(self, agents_file, workflow_file, title="Maestro workflow"):
+        self.title = title
+        self.agents_file = agents_file
+        self.workflow_file = workflow_file
+
+        self.agents_yaml = parse_yaml(agents_file)
+        self.workflow_yaml = parse_yaml(workflow_file)
+        self.workflow = self.__create_workflow(self.agents_yaml, self.workflow_yaml)
+
+    def setup_ui(self):        
+        self.__initialize_session_state()
+        self.__add_workflow_name_and_files()
+        self.__create_workflow_ui()
+        self.__create_chat_messages()
+        self.__create_chat_input()
+        self.__add__chat_reset_button()
+
+    # private
+
+    def __add_workflow_name_and_files(self):
+        # add line of workflow: title, agents.yaml, and workflow.yaml
+        st.markdown(f"### {self.workflow_yaml[0]['metadata']['name']}")
+        cols = st.columns(4)
+        with cols[0]:
+            with st.popover("agents.yaml"):
+                st.markdown("## Formatted agents YAML")
+                st.code(read_file(self.agents_file), language="yaml", line_numbers=True, wrap_lines=False, height=700)
+        with cols[1]:
+            with st.popover("workflow.yaml"):
+                st.markdown("## Formatted workflow YAML")
+                st.code(read_file(self.workflow_file), language="yaml", line_numbers=True, wrap_lines=False, height=700)
+
+    def __initialize_session_state(self):
+        # Initialize session state for chat history
+        if "messages" not in st.session_state:
+            st.session_state.messages = [
+                {
+                    "role": "assistant", 
+                    "content": "Welcome to Maestro workflow?"
+                }]
+
+    def __add__chat_reset_button(self):
+        # Add reset button
+        def reset_conversation():
+            st.session_state.conversation = None
+            st.session_state.chat_history = None
+            message_placeholder = st.empty()
+
+        st.button('Reset', on_click=reset_conversation, key=f"reset_button:{self.title}")
+
+    def __create_chat_input(self):
+        prompt = st.chat_input(f"{self.workflow_yaml[0]['spec']['template']['prompt']}", key=f"chat_input:{self.title}")
+        if prompt:
+            # Add user message to chat history
+            st.session_state.messages.append({"role": "user", "content": prompt})
+            
+            # Display user message
+            with st.chat_message("user", avatar="👤"):
+                st.markdown(prompt)
+            
+            # Display assistant response
+            with st.chat_message("assistant", avatar="🤖"):
+                message_placeholder = st.empty()
+                message_placeholder.markdown("Thinking...")
+
+                self.__start_workflow()
+
+                # stream response
+                responses = ''
+                for response in st.write_stream(StreamlitWorkflowUI.__generate_output):
+                    message_placeholder.markdown(response)
+                    responses += f"{response}"
+                    
+            # Add assistant response to chat history
+            st.session_state.messages.append({"role": "assistant", "content": responses})
+
+    def __create_chat_messages(self):
+        # Display chat messages
+        for message in st.session_state.messages:
+            if message["role"] == "assistant":
+                with st.chat_message(message["role"], avatar="🤖"):
+                    st.markdown(message["content"])
+            else:
+                with st.chat_message(message["role"], avatar="👤"):
+                    st.markdown(message["content"])
+
+        # Function to process user input
+        async def process_query(query):
+            try:
+                return await workflow.run()
+            except Exception as e:
+                return f"An error occurred: {str(e)}"
+
+    def __create_workflow_ui(self):
+        # create workflow
+        global output
+        global workflow_instance
+        try:
+            workflow_instance = self.__create_workflow(self.agents_yaml, self.workflow_yaml[0])
+        except Exception as e:
+            traceback.print_exc()
+            raise RuntimeError(f"Unable to create agents: {str(e)}") from e
+        
+        # add workflow mermaid diagram to page
+        st.markdown("")
+        st.markdown(f"###### _Sequence diagram of workflow_")
+        mermaid_diagram = workflow_instance.to_mermaid()
+        stmd.st_mermaid(mermaid_diagram, key=f"mermaid_diagram:{self.title}")
+
+    def __generate_output():
+        global output
+        global position
+        position = 0
+        message = output.getvalue()
+        if len(message) > position:
+            lines = output.getvalue()[position:].splitlines()
+            for line in lines:
+                yield f"{line}\n\n"
+            position = len(message)
+
+    def __start_workflow(self):
+        global output
+        output = io.StringIO()
+        sys.stdout = output
+        asyncio.run(workflow_instance.run())
+
+    def __create_workflow(self, agents_yaml, workflow_yaml):
+        return Workflow(agents_yaml, workflow_yaml)

--- a/maestro/src/workflow.py
+++ b/maestro/src/workflow.py
@@ -105,8 +105,10 @@ class Workflow:
 
         return Mermaid(workflow, kind, orientation).to_markdown()
 
-    async def run(self):
+    async def run(self, prompt=''):
         """Execute workflow."""
+        if prompt != '':
+            self.workflow['spec']['template']['prompt'] = prompt
         self.create_or_restore_agents(self.agent_defs, self.workflow)
         return await self._condition()
 

--- a/maestro/tests/cli/test_commands.py
+++ b/maestro/tests/cli/test_commands.py
@@ -301,5 +301,40 @@ class MermaidCommand(TestCommand):
         except Exception as e:
             self.fail(f"Exception running command: {str(e)}")
 
+# `meta-agents` commmand tests
+class MetaAgentsCommand(TestCommand):
+    def setUp(self):
+        self.args = {
+                        '--dry-run': False,
+                        '--help': False,
+                        '--verbose': True,
+                        '--silent': False,
+                        '--version': False,                        
+                        'AGENTS_FILE': None,
+                        'SCHEMA_FILE': None,
+                        'WORKFLOW_FILE': None,
+                        'TEXT_FILE': self.get_fixture('meta_agents/simple_prompt.txt'),
+                        'deploy': False,
+                        'run': False,
+                        'create': False,
+                        'mermaid': False,
+                        'validate': False,
+                        'meta-agents': True
+
+                    }
+        self.command = CLI(self.args).command()
+    
+    def tearDown(self):
+        self.args = {}
+        self.command = None
+        
+    def test_meta_agents(self):
+        self.assertTrue(self.command.name() == 'meta-agents')
+        try:
+            rc = self.command.execute()
+            self.assertTrue(rc == 0)
+        except Exception as e:
+            self.fail(f"Exception running command: {str(e)}")
+
 if __name__ == '__main__':
     unittest.main()

--- a/maestro/tests/meta_agents/simple_prompt.txt
+++ b/maestro/tests/meta_agents/simple_prompt.txt
@@ -1,0 +1,3 @@
+number of agents: 2
+agent1: weather_fetcher – Retrieves weather data for a given location using OpenMeteo tool. 
+agent2: temperature_comparator – Compares the retrieved temperature with historical averages using OpenMeteo tool.


### PR DESCRIPTION
Still TODOs:

- [x] since meta-agents prompts are multiple lines need to change the default `st.chat_input()` to be multilines
- [x] no UI yet for the generated workflow but should be easy if we can capture when tab is selected and pass the files
- [ ] does not show mermaid for the meta-agents workflow workflow
- [ ] needs testing

@george-lhj this is not fully ready but worth trying at least to test the meta-agents workflow for generating the agents. You can try it with:

```bash
./maestro meta-agents tests/meta_agents/simple_prompt.txt
```

OR change ` tests/meta_agents/simple_prompt.txt` to a different file. If file does not exist it should default to a simple prompt.

When complete and merged this will close issue #365 
