### PR TITLE
added Markdown formatter in prep for demo

### DIFF
--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
@@ -161,3 +161,18 @@ spec:
     agent2: trend_analyzer – Analyzes trends and compares them to the market average.
   tools:
     - 'LLM'
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: markdown formatter
+  labels:
+    app: meta-agent
+spec:
+  model: llama3.1
+  description: "takes a YAML file and formats it to be more readable in a code block"
+  instructions: |
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is  output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. Do not output anything other than the final yaml file, and directly print it here with a code block.
+  tools:
+    - 'LLM'

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
@@ -173,6 +173,6 @@ spec:
   model: llama3.1
   description: "takes a YAML file and formats it to be more readable in a code block"
   instructions: |
-    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is to output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
@@ -173,6 +173,6 @@ spec:
   model: llama3.1
   description: "takes a YAML file and formats it to be more readable in a code block"
   instructions: |
-    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is  output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. Do not output anything other than the final yaml file, and directly print it here with a code block.
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/workflow.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/workflow.yaml
@@ -14,6 +14,7 @@ spec:
       - NLP Agent Planner V2
       - Format Input Agent V2
       - Create Agent YAML V2
+      - markdown formatter
     prompt: I want 4 agents in order to ultimately decide what activities I should do in a given location. First agent get the current temperature given a location, the second to compare that temperature with historical temperatures, then another agent to provide a list of activities if it's cold or conversely another agent to proivde a list of activities if it is hot.
     steps:
       - name: English Instructions to Prompt
@@ -22,3 +23,5 @@ spec:
         agent: Format Input Agent V2
       - name: Creating Agent YAML Workflow
         agent: Create Agent YAML V2
+      - name: Readable output
+        agent: markdown formatter

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
@@ -202,6 +202,6 @@ spec:
   model: llama3.1
   description: "takes a YAML file and formats it to be more readable in a code block"
   instructions: |
-    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is  output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. Do not output anything other than the final yaml file, and directly print it here with a code block.
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
@@ -202,6 +202,6 @@ spec:
   model: llama3.1
   description: "takes a YAML file and formats it to be more readable in a code block"
   instructions: |
-    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is to output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
@@ -190,3 +190,18 @@ spec:
           except requests.exceptions.RequestException as e:
               print(f"⚠️ Error fetching schema: {e}")
               return {"schema": {}}  # Return an empty schema if fetching fails
+
+--- 
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: markdown formatter
+  labels:
+    app: meta-agent
+spec:
+  model: llama3.1
+  description: "takes a YAML file and formats it to be more readable in a code block"
+  instructions: |
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is  output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. Do not output anything other than the final yaml file, and directly print it here with a code block.
+  tools:
+    - 'LLM'

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/workflow.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/workflow.yaml
@@ -14,6 +14,7 @@ spec:
       - NLP Agent Planner V2
       - Format Workflow Agent V2
       - Workflow V2
+      - markdown formatter
     prompt: I want 4 agents in order to ultimately decide what activities I should do in a given location. First agent get the current temperature given a location, the second to compare that temperature with historical temperatures, then another agent to provide a list of activities if it's cold or conversely another agent to proivde a list of activities if it is hot.
     steps:
       - name: English Instructions to Prompt
@@ -22,3 +23,5 @@ spec:
         agent: Format Workflow Agent V2
       - name: Creating Workflow YAML file
         agent: Workflow V2
+      - name: Readable output
+        agent: markdown formatter

--- a/maestro/src/agents/meta_agent/agents.yaml
+++ b/maestro/src/agents/meta_agent/agents.yaml
@@ -320,6 +320,6 @@ spec:
   model: llama3.1
   description: "takes a YAML file and formats it to be more readable in a code block"
   instructions: |
-    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is to output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'

--- a/maestro/src/agents/meta_agent/agents.yaml
+++ b/maestro/src/agents/meta_agent/agents.yaml
@@ -320,6 +320,6 @@ spec:
   model: llama3.1
   description: "takes a YAML file and formats it to be more readable in a code block"
   instructions: |
-    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. Do not output anything other than the final yaml file, and directly print it here with a code block.
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'

--- a/maestro/src/agents/meta_agent/agents.yaml
+++ b/maestro/src/agents/meta_agent/agents.yaml
@@ -308,3 +308,18 @@ spec:
         - The output **must match the given structure exactly**."
   tools:
     - 'LLM'
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: markdown formatter
+  labels:
+    app: meta-agent
+spec:
+  model: llama3.1
+  description: "takes a YAML file and formats it to be more readable in a code block"
+  instructions: |
+    You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. Do not output anything other than the final yaml file, and directly print it here with a code block.
+  tools:
+    - 'LLM'

--- a/maestro/src/agents/meta_agent/workflow_agent.yaml
+++ b/maestro/src/agents/meta_agent/workflow_agent.yaml
@@ -14,6 +14,7 @@ spec:
       - NLP Agent Planner V2
       - Format Input Agent V2
       - Create Agent YAML V2
+      - markdown formatter
     prompt: I want to compare the current weather with the historical averages. To do this, I probably will need 2 agents, one to retrieve the weather and one to compare to the historical average.
     steps:
       - name: English Instructions to Prompt
@@ -22,3 +23,5 @@ spec:
         agent: Format Input Agent V2
       - name: Creating Agent YAML Workflow
         agent: Create Agent YAML V2
+      - name: Readable output
+        agent: markdown formatter

--- a/maestro/src/agents/meta_agent/workflow_workflow.yaml
+++ b/maestro/src/agents/meta_agent/workflow_workflow.yaml
@@ -14,6 +14,7 @@ spec:
       - NLP Agent Planner V2
       - Format Workflow Agent V2
       - Workflow V2
+      - markdown formatter
     prompt: I want to compare the current weather with the historical averages. To do this, I probably will need 2 agents, one to retrieve the weather and one to compare to the historical average.
     steps:
       - name: English Instructions to Prompt
@@ -22,3 +23,5 @@ spec:
         agent: Format Workflow Agent V2
       - name: Creating Workflow YAML file
         agent: Workflow V2
+      - name: Readable output
+        agent: markdown formatter

--- a/maestro/tests/meta_agents/weather_prompt.txt
+++ b/maestro/tests/meta_agents/weather_prompt.txt
@@ -1,0 +1,1 @@
+I want to compare the current weather with the historical averages. To do this, I will need 2 agents, one to retrieve the weather and one to compare to the historical average.


### PR DESCRIPTION
Added a formatting agent so that the yaml output on the deploy looks more readable.
Heres what it looks like:

<img width="713" alt="Screenshot 2025-04-03 at 12 13 40 PM" src="https://github.com/user-attachments/assets/70f1292e-58c7-44ff-9a13-42f51d081e2e" />
