### PR TITLE
feature: load and create generated <agents/workflow>.yaml files

### DIFF
--- a/maestro/cli/streamlit_meta_agents_deploy.py
+++ b/maestro/cli/streamlit_meta_agents_deploy.py
@@ -11,6 +11,19 @@ from streamlit_workflow_ui import StreamlitWorkflowUI
 from cli.common import Console, parse_yaml, read_file
 
 def deploy_meta_agents_streamlit(prompt_text_file):
+    print("!!!!")
+    generated_agent = "generated_agent"
+    generated_workflow = "generated_workflow"
+
+    def load_generated():
+        print(os.getcwd())
+        if os.path.exists(generated_agent):
+            agent_file = generated_agent
+            st.session_state.agent_file = agent_file
+        if os.path.exists(generated_workflow):
+            workflow_file = generated_workflow
+            st.session_state.workflow_file = workflow_file
+
     prompt = "Enter your maestro meta-agents prompt here"
     try:
         prompt = read_file(prompt_text_file)
@@ -49,11 +62,18 @@ def deploy_meta_agents_streamlit(prompt_text_file):
 
     with generated_workflow_tab:
         st.header("Meta-agents generated ⌇ -> Workflow")
+        # Add load generated file button
+        st.button('Load generated files', on_click=load_generated)
         agent_file = st.file_uploader("Choose agents.yaml", key='agents.yaml')
         workflow_file = st.file_uploader("Choose agents.yaml", key='workflow.yaml')
 
         if agent_file is not None and workflow_file is not None:
             ma_gent_workflow_workflow_ui = StreamlitWorkflowUI(agent_file.getvalue().decode("utf-8"), workflow_file.getvalue().decode("utf-8"), '', 'Maestro meta-agents generated workflow')
+            ma_gent_workflow_workflow_ui.setup_ui()
+        elif "workflow_file" in st.session_state and "agent_file" in st.session_state:
+            agent_file = st.session_state.agent_file
+            workflow_file = st.session_state.workflow_file
+            ma_gent_workflow_workflow_ui = StreamlitWorkflowUI(agent_file, workflow_file, '', 'Maestro meta-agents generated workflow')
             ma_gent_workflow_workflow_ui.setup_ui()
 
 if __name__ == '__main__':

--- a/maestro/cli/streamlit_meta_agents_deploy.py
+++ b/maestro/cli/streamlit_meta_agents_deploy.py
@@ -50,12 +50,12 @@ def deploy_meta_agents_streamlit(prompt_text_file):
 
     with agents_tab:
         st.header("Meta-agents 🤖 -> agents.yaml")
-        ma_agents_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', prompt, 'Maestro meta-agents agents workflow')
+        ma_agents_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', prompt, 'Maestro meta-agents agents workflow', generated_agent)
         ma_agents_workflow_ui.setup_ui()
     
     with workflow_tab:
         st.header("Meta-agents 🤖 -> workflow.yaml")
-        ma_workflow_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_workflow.yaml', prompt, 'Maestro meta-agents workflow')
+        ma_workflow_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_workflow.yaml', prompt, 'Maestro meta-agents workflow', generated_workflow)
         ma_workflow_workflow_ui.setup_ui()
 
     with generated_workflow_tab:

--- a/maestro/cli/streamlit_meta_agents_deploy.py
+++ b/maestro/cli/streamlit_meta_agents_deploy.py
@@ -11,12 +11,10 @@ from streamlit_workflow_ui import StreamlitWorkflowUI
 from cli.common import Console, parse_yaml, read_file
 
 def deploy_meta_agents_streamlit(prompt_text_file):
-    print("!!!!")
     generated_agent = "generated_agent"
     generated_workflow = "generated_workflow"
 
     def load_generated():
-        print(os.getcwd())
         if os.path.exists(generated_agent):
             agent_file = generated_agent
             st.session_state.agent_file = agent_file

--- a/maestro/cli/streamlit_workflow_ui.py
+++ b/maestro/cli/streamlit_workflow_ui.py
@@ -11,12 +11,13 @@ sys_stdout = sys.stdout
 global workflow_instance
 
 class StreamlitWorkflowUI:
-    def __init__(self, agents_file, workflow_file, prompt='', title='Maestro workflow'):
+    def __init__(self, agents_file, workflow_file, prompt='', title='Maestro workflow', save_file=''):
         self.title = title
         self.prompt = prompt
         self.initial_prompt = 'Enter your prompt here'
         self.agents_file = agents_file
         self.workflow_file = workflow_file
+        self.save_file = save_file
 
         self.agents_yaml = self.__read_or_parse_yaml(agents_file)
         self.workflow_yaml = self.__read_or_parse_yaml(workflow_file)
@@ -119,9 +120,21 @@ class StreamlitWorkflowUI:
                 # stream response
                 while True:
                     message = ""
+                    file_contents = ""
+                    save_to_file = False
                     lines = StreamlitWorkflowUI.__generate_output().splitlines()
                     for line in lines:
                         message = message + f"{line}\n\n"
+                        if save_to_file:
+                            if "</file>" in line:
+                                save_to_file = False
+                                with open(self.save_file, "w") as file:
+                                    file.write(file_contents)
+                                file_contents = ""
+                            else:
+                                file_contents = file_contents + f"{line}\n\n" 
+                        if "<file start>" in line:
+                            save_to_file = True
                     message_placeholder.markdown(message)
                     time.sleep(1)
                     if not thread.is_alive():

--- a/maestro/cli/streamlit_workflow_ui.py
+++ b/maestro/cli/streamlit_workflow_ui.py
@@ -142,6 +142,16 @@ class StreamlitWorkflowUI:
                         lines = StreamlitWorkflowUI.__generate_output().splitlines()
                         for line in lines:
                             message = message + f"{line}\n\n"
+                            if save_to_file:
+                                if "</file>" in line:
+                                    save_to_file = False
+                                    with open(self.save_file, "w") as file:
+                                        file.write(file_contents)
+                                    file_contents = ""
+                                else:
+                                    file_contents = file_contents + f"{line}\n\n"
+                            if "<file start>" in line:
+                                save_to_file = True
                         message_placeholder.markdown(message)
                         break
 


### PR DESCRIPTION
Fix #395 

This PR adds "Load generated files" button in the "Generated" tab.  This expects the generated file names are 
```
    generated_agent = "generated_agent"
    generated_workflow = "generated_workflow"
```
in the working directory.