### PR TITLE
Add parsers

### DIFF
--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
@@ -197,8 +197,6 @@ spec:
     </file>
     Example Input:
 
-    yaml
-    Copy
     apiVersion: maestro/v1alpha1
     kind: Workflow
     metadata:
@@ -221,8 +219,6 @@ spec:
             agent: hot-or-not Agent
     Example Output:
 
-    yaml
-    Copy
     <file start>
     apiVersion: maestro/v1alpha1
     kind: Workflow

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
@@ -187,7 +187,7 @@ metadata:
     app: meta-agent
 spec:
   model: llama3.1
-  description: "takes a YAML file and formats it to be more readable in a code block" 
+  description: "adds file tags for parsing" 
   instructions: |
     When given an input query, you must output the exact input with two additional wrapper tags. Do not modify, rewrap, or remove any of the original newlines, bullet points, or spacing. Simply add the tag <file start> at the very beginning, and add the tag </file> at the very end, each on its own separate line.
 

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/agents.yaml
@@ -176,3 +176,79 @@ spec:
     You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is to output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'
+
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: tagger agent
+  labels:
+    app: meta-agent
+spec:
+  model: llama3.1
+  description: "takes a YAML file and formats it to be more readable in a code block" 
+  instructions: |
+    When given an input query, you must output the exact input with two additional wrapper tags. Do not modify, rewrap, or remove any of the original newlines, bullet points, or spacing. Simply add the tag <file start> at the very beginning, and add the tag </file> at the very end, each on its own separate line.
+
+    Desired Output Format:
+    <file start>
+    [Content exactly as provided, preserving all newlines, indents, and formatting]
+    </file>
+    Example Input:
+
+    yaml
+    Copy
+    apiVersion: maestro/v1alpha1
+    kind: Workflow
+    metadata:
+      name: maestro-deployment
+      labels:
+        app: mas-example
+    spec:
+      template:
+        metadata:
+          labels:
+            app: mas-example
+        agents:
+          - Temperature Agent
+          - hot-or-not Agent
+        prompt: New York City
+        steps:
+          - name: get_temperature
+            agent: Temperature Agent
+          - name: compare_temperature
+            agent: hot-or-not Agent
+    Example Output:
+
+    yaml
+    Copy
+    <file start>
+    apiVersion: maestro/v1alpha1
+    kind: Workflow
+    metadata:
+      name: maestro-deployment
+      labels:
+        app: mas-example
+    spec:
+      template:
+        metadata:
+          labels:
+            app: mas-example
+        agents:
+          - Temperature Agent
+          - hot-or-not Agent
+        prompt: New York City
+        steps:
+          - name: get_temperature
+            agent: Temperature Agent
+          - name: compare_temperature
+            agent: hot-or-not Agent
+    </file>
+    Important:
+
+    The agent should not combine all the text into a single paragraph.
+
+    Each line in the input should appear as a separate line in the output, exactly as it was provided.
+
+    Please use this exact prompt to ensure the output maintains the original formatting with the required wrapper tags.

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/workflow.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/agents/workflow.yaml
@@ -15,6 +15,7 @@ spec:
       - Format Input Agent V2
       - Create Agent YAML V2
       - markdown formatter
+      - tagger agent
     prompt: I want 4 agents in order to ultimately decide what activities I should do in a given location. First agent get the current temperature given a location, the second to compare that temperature with historical temperatures, then another agent to provide a list of activities if it's cold or conversely another agent to proivde a list of activities if it is hot.
     steps:
       - name: English Instructions to Prompt
@@ -25,3 +26,5 @@ spec:
         agent: Create Agent YAML V2
       - name: Readable output
         agent: markdown formatter
+      - name: add tags
+        agent: tagger agent

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
@@ -225,8 +225,6 @@ spec:
     </file>
     Example Input:
 
-    yaml
-    Copy
     apiVersion: maestro/v1alpha1
     kind: Workflow
     metadata:
@@ -249,8 +247,6 @@ spec:
             agent: hot-or-not Agent
     Example Output:
 
-    yaml
-    Copy
     <file start>
     apiVersion: maestro/v1alpha1
     kind: Workflow

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
@@ -215,7 +215,7 @@ metadata:
     app: meta-agent
 spec:
   model: llama3.1
-  description: "takes a YAML file and formats it to be more readable in a code block" 
+  description: "adds file tags for parsing" 
   instructions: |
     When given an input query, you must output the exact input with two additional wrapper tags. Do not modify, rewrap, or remove any of the original newlines, bullet points, or spacing. Simply add the tag <file start> at the very beginning, and add the tag </file> at the very end, each on its own separate line.
 

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/agents.yaml
@@ -205,3 +205,78 @@ spec:
     You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is to output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: tagger agent
+  labels:
+    app: meta-agent
+spec:
+  model: llama3.1
+  description: "takes a YAML file and formats it to be more readable in a code block" 
+  instructions: |
+    When given an input query, you must output the exact input with two additional wrapper tags. Do not modify, rewrap, or remove any of the original newlines, bullet points, or spacing. Simply add the tag <file start> at the very beginning, and add the tag </file> at the very end, each on its own separate line.
+
+    Desired Output Format:
+    <file start>
+    [Content exactly as provided, preserving all newlines, indents, and formatting]
+    </file>
+    Example Input:
+
+    yaml
+    Copy
+    apiVersion: maestro/v1alpha1
+    kind: Workflow
+    metadata:
+      name: maestro-deployment
+      labels:
+        app: mas-example
+    spec:
+      template:
+        metadata:
+          labels:
+            app: mas-example
+        agents:
+          - Temperature Agent
+          - hot-or-not Agent
+        prompt: New York City
+        steps:
+          - name: get_temperature
+            agent: Temperature Agent
+          - name: compare_temperature
+            agent: hot-or-not Agent
+    Example Output:
+
+    yaml
+    Copy
+    <file start>
+    apiVersion: maestro/v1alpha1
+    kind: Workflow
+    metadata:
+      name: maestro-deployment
+      labels:
+        app: mas-example
+    spec:
+      template:
+        metadata:
+          labels:
+            app: mas-example
+        agents:
+          - Temperature Agent
+          - hot-or-not Agent
+        prompt: New York City
+        steps:
+          - name: get_temperature
+            agent: Temperature Agent
+          - name: compare_temperature
+            agent: hot-or-not Agent
+    </file>
+    Important:
+
+    The agent should not combine all the text into a single paragraph.
+
+    Each line in the input should appear as a separate line in the output, exactly as it was provided.
+
+    Please use this exact prompt to ensure the output maintains the original formatting with the required wrapper tags.

--- a/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/workflow.yaml
+++ b/maestro/demos/workflows/meta-agents/activity-planner.ai/workflow/workflow.yaml
@@ -15,6 +15,7 @@ spec:
       - Format Workflow Agent V2
       - Workflow V2
       - markdown formatter
+      - tagger agent
     prompt: I want 4 agents in order to ultimately decide what activities I should do in a given location. First agent get the current temperature given a location, the second to compare that temperature with historical temperatures, then another agent to provide a list of activities if it's cold or conversely another agent to proivde a list of activities if it is hot.
     steps:
       - name: English Instructions to Prompt
@@ -25,3 +26,5 @@ spec:
         agent: Workflow V2
       - name: Readable output
         agent: markdown formatter
+      - name: add tags
+        agent: tagger agent

--- a/maestro/src/agents/meta_agent/agents.yaml
+++ b/maestro/src/agents/meta_agent/agents.yaml
@@ -323,3 +323,78 @@ spec:
     You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is to output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'
+    
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: tagger agent
+  labels:
+    app: meta-agent
+spec:
+  model: llama3.1
+  description: "takes a YAML file and formats it to be more readable in a code block" 
+  instructions: |
+    When given an input query, you must output the exact input with two additional wrapper tags. Do not modify, rewrap, or remove any of the original newlines, bullet points, or spacing. Simply add the tag <file start> at the very beginning, and add the tag </file> at the very end, each on its own separate line.
+
+    Desired Output Format:
+    <file start>
+    [Content exactly as provided, preserving all newlines, indents, and formatting]
+    </file>
+    Example Input:
+
+    yaml
+    Copy
+    apiVersion: maestro/v1alpha1
+    kind: Workflow
+    metadata:
+      name: maestro-deployment
+      labels:
+        app: mas-example
+    spec:
+      template:
+        metadata:
+          labels:
+            app: mas-example
+        agents:
+          - Temperature Agent
+          - hot-or-not Agent
+        prompt: New York City
+        steps:
+          - name: get_temperature
+            agent: Temperature Agent
+          - name: compare_temperature
+            agent: hot-or-not Agent
+    Example Output:
+
+    yaml
+    Copy
+    <file start>
+    apiVersion: maestro/v1alpha1
+    kind: Workflow
+    metadata:
+      name: maestro-deployment
+      labels:
+        app: mas-example
+    spec:
+      template:
+        metadata:
+          labels:
+            app: mas-example
+        agents:
+          - Temperature Agent
+          - hot-or-not Agent
+        prompt: New York City
+        steps:
+          - name: get_temperature
+            agent: Temperature Agent
+          - name: compare_temperature
+            agent: hot-or-not Agent
+    </file>
+    Important:
+
+    The agent should not combine all the text into a single paragraph.
+
+    Each line in the input should appear as a separate line in the output, exactly as it was provided.
+
+    Please use this exact prompt to ensure the output maintains the original formatting with the required wrapper tags.

--- a/maestro/src/agents/meta_agent/agents.yaml
+++ b/maestro/src/agents/meta_agent/agents.yaml
@@ -318,12 +318,12 @@ metadata:
     app: meta-agent
 spec:
   model: llama3.1
-  description: "takes a YAML file and formats it to be more readable in a code block"
+  description: "adds file tags for parsing"
   instructions: |
     You are a YAML formatting assistant. The given input will be a valid yaml file that is a bit hard to read. Your task is to output it properly inside a markdown code block to make it easier for the human eye to read. Do not execute or run any part of the YAML; simply reformat and present it exactly as plain text. Do not change any of the value/text. In the final yaml file, try not to have extra spaces between each line. Do not output anything other than the final yaml file, and directly print it here with a code block.
   tools:
     - 'LLM'
-    
+
 ---
 apiVersion: maestro/v1alpha1
 kind: Agent

--- a/maestro/src/agents/meta_agent/agents.yaml
+++ b/maestro/src/agents/meta_agent/agents.yaml
@@ -343,8 +343,6 @@ spec:
     </file>
     Example Input:
 
-    yaml
-    Copy
     apiVersion: maestro/v1alpha1
     kind: Workflow
     metadata:
@@ -367,8 +365,6 @@ spec:
             agent: hot-or-not Agent
     Example Output:
 
-    yaml
-    Copy
     <file start>
     apiVersion: maestro/v1alpha1
     kind: Workflow

--- a/maestro/src/agents/meta_agent/workflow_agent.yaml
+++ b/maestro/src/agents/meta_agent/workflow_agent.yaml
@@ -15,6 +15,7 @@ spec:
       - Format Input Agent V2
       - Create Agent YAML V2
       - markdown formatter
+      - tagger agent
     prompt: I want to compare the current weather with the historical averages. To do this, I probably will need 2 agents, one to retrieve the weather and one to compare to the historical average.
     steps:
       - name: English Instructions to Prompt
@@ -25,3 +26,5 @@ spec:
         agent: Create Agent YAML V2
       - name: Readable output
         agent: markdown formatter
+      - name: add tags
+        agent: tagger agent

--- a/maestro/src/agents/meta_agent/workflow_workflow.yaml
+++ b/maestro/src/agents/meta_agent/workflow_workflow.yaml
@@ -15,6 +15,7 @@ spec:
       - Format Workflow Agent V2
       - Workflow V2
       - markdown formatter
+      - tagger agent
     prompt: I want to compare the current weather with the historical averages. To do this, I probably will need 2 agents, one to retrieve the weather and one to compare to the historical average.
     steps:
       - name: English Instructions to Prompt
@@ -25,3 +26,5 @@ spec:
         agent: Workflow V2
       - name: Readable output
         agent: markdown formatter
+      - name: add tags
+        agent: tagger agent


### PR DESCRIPTION
fixes #394 

add an agent to takes in the final yaml format of the output, and then adds tags

<file start>
content
</file>

so that we can parse the content and directly upload


here is what output looks like:

<img width="712" alt="Screenshot 2025-04-08 at 2 50 47 PM" src="https://github.com/user-attachments/assets/7827a80d-85f5-495a-8596-ca60c1dcb655" />
