### PR TITLE
Streamline remote/local agent

### DIFF
--- a/maestro/demos/workflows/activity-planner.ai/agents.yaml
+++ b/maestro/demos/workflows/activity-planner.ai/agents.yaml
@@ -6,6 +6,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
+  framework: beeai
+  mode: remote
   description: Get the current weather
   tools:
     - code_interpreter
@@ -22,6 +24,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
+  framework: beeai
+  mode: remote
   description: Is the current temperature hotter or colder than the historical monthly average.
   tools:
     - code_interpreter
@@ -39,6 +43,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
+  framework: beeai
+  mode: remote
   description: Find activities suited to do in the colder weather at a given location.
   tools:
     - code_interpreter
@@ -56,6 +62,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
+  framework: beeai
+  mode: remote
   description: Find activities suited to do in the hotter weather at a given location.
   tools:
     - code_interpreter

--- a/maestro/demos/workflows/activity-planner.ai/local_agent.yaml
+++ b/maestro/demos/workflows/activity-planner.ai/local_agent.yaml
@@ -6,7 +6,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: Get the current weather
   tools:
     - code_interpreter
@@ -23,7 +24,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
-  framework: beeailocal
+  mode: local
+  framework: beeai
   description: Is the current temperature hotter or colder than the historical monthly average.
   tools:
     - code_interpreter
@@ -41,7 +43,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: Find activities suited to do in the colder weather at a given location.
   tools:
     - code_interpreter
@@ -59,7 +62,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: Find activities suited to do in the hotter weather at a given location.
   tools:
     - code_interpreter

--- a/maestro/demos/workflows/weather-checker.ai/agents.yaml
+++ b/maestro/demos/workflows/weather-checker.ai/agents.yaml
@@ -6,6 +6,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
+  framework: beeai
+  mode: remote
   description: Get the current weather
   tools:
     - code_interpreter
@@ -20,6 +22,8 @@ metadata:
     app: mas-example
 spec:
   model: "llama3.1:latest"
+  framework: beeai
+  mode: remote
   description: Is the current temperature hotter than usual?
   tools:
     - code_interpreter

--- a/maestro/demos/workflows/weather-checker.ai/local_agents.yaml
+++ b/maestro/demos/workflows/weather-checker.ai/local_agents.yaml
@@ -6,7 +6,8 @@ metadata:
     app: mas-example
 spec:
   model: llama3.1
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: Get the current weather
   tools:
     - code_interpreter
@@ -21,7 +22,8 @@ metadata:
     app: mas-example
 spec:
   model: llama3.1
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: Is the current temperature hotter than usual?
   tools:
     - code_interpreter

--- a/maestro/schemas/agent_schema.json
+++ b/maestro/schemas/agent_schema.json
@@ -40,6 +40,14 @@
           "type": "string",
           "description": "The LLM model for this agent"
         },
+        "framework": {
+          "type": "string",
+            "description": "The agent framework type. beeai, crewai, remote or mock"
+        },
+        "mode": {
+          "type": "string",
+          "description": "The mode of the agent.  remote or local"
+        },
         "tools": {
           "type": "array",
           "description": "tool list of the agent",

--- a/maestro/src/agents/agent_factory.py
+++ b/maestro/src/agents/agent_factory.py
@@ -2,8 +2,7 @@
 from enum import StrEnum
 from typing import Callable, Type, Union
 
-from .beeai_agent import BeeAIAgent
-from .beeai_local_agent import BeeAILocalAgent
+from .beeai_agent import BeeAIAgent, BeeAILocalAgent
 from .crewai_agent import CrewAIAgent
 from .remote_agent import RemoteAgent
 from .mock_agent import MockAgent
@@ -22,7 +21,6 @@ EMOJIS = {
 class AgentFramework(StrEnum):
     """Enumeration of supported frameworks"""
     BEEAI = "beeai"
-    BEEAILOCAL = "beeailocal"
     CREWAI = "crewai"
     MOCK = 'mock'
     REMOTE = 'remote'
@@ -34,7 +32,7 @@ class AgentFramework(StrEnum):
 class AgentFactory:
     """Factory class for handling agent frameworks"""
     @staticmethod
-    def create_agent(framework: AgentFramework) -> Callable[..., Union[BeeAIAgent, CrewAIAgent]]:
+    def create_agent(framework: AgentFramework, mode="local") -> Callable[..., Union[BeeAIAgent, BeeAILocalAgent, CrewAIAgent, RemoteAgent, MockAgent]]:
         """Create an instance of the specified agent framework.
 
         Args:
@@ -44,19 +42,28 @@ class AgentFactory:
             A new instance of the corresponding agent class.
         """
         factories = {
-            AgentFramework.BEEAI: BeeAIAgent,
-            AgentFramework.BEEAILOCAL: BeeAILocalAgent,
+            AgentFramework.BEEAI: BeeAILocalAgent,
             AgentFramework.CREWAI: CrewAIAgent,
+            AgentFramework.MOCK: MockAgent
+        }
+
+        remote_factories = {
+            AgentFramework.BEEAI: BeeAIAgent,
             AgentFramework.REMOTE: RemoteAgent,
             AgentFramework.MOCK: MockAgent
         }
 
         if framework not in factories:
             raise ValueError(f"Unknown framework: {framework}")
+
+        if mode == "local":
+            return factories[framework]
+        else:
+            return remote_factories[framework]
         
         return factories[framework]
 
     @classmethod
-    def get_factory(cls, framework: str) -> Callable[..., Union[BeeAIAgent, BeeAILocalAgent, CrewAIAgent]]:
+    def get_factory(cls, framework: str, mode="local") -> Callable[..., Union[BeeAIAgent, BeeAILocalAgent, CrewAIAgent, RemoteAgent, MockAgent]]:
         """Get a factory function for the specified agent type."""
-        return cls.create_agent(framework)
+        return cls.create_agent(framework, mode)

--- a/maestro/src/agents/agent_factory.py
+++ b/maestro/src/agents/agent_factory.py
@@ -56,10 +56,10 @@ class AgentFactory:
         if framework not in factories:
             raise ValueError(f"Unknown framework: {framework}")
 
-        if mode == "local":
-            return factories[framework]
-        else:
+        if mode == "remote":
             return remote_factories[framework]
+        else:
+            return factories[framework]
         
         return factories[framework]
 

--- a/maestro/src/agents/beeai_agent.py
+++ b/maestro/src/agents/beeai_agent.py
@@ -9,6 +9,21 @@ from openai import AssistantEventHandler, OpenAI
 from openai.types.beta import AssistantStreamEvent
 from openai.types.beta.threads.runs import RunStep, RunStepDelta, ToolCall
 
+from typing import Any
+from pydantic import BaseModel
+
+from beeai_framework.adapters.ollama import OllamaChatModel
+from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents.react import ReActAgent
+from beeai_framework.emitter import Emitter, EmitterOptions, EventMeta
+from beeai_framework.errors import FrameworkError
+from beeai_framework.memory import UnconstrainedMemory
+from beeai_framework.template import PromptTemplateInput
+from beeai_framework.tools import AnyTool
+from beeai_framework.tools.search import DuckDuckGoSearchTool
+from beeai_framework.tools.weather import OpenMeteoTool
+from beeai_framework.utils import AbortSignal
+
 from src.agents.agent import Agent
 
 dotenv.load_dotenv()
@@ -129,3 +144,142 @@ class BeeAIAgent(Agent):
         print(f"🐝 Response from {self.agent_name}: {answer}\n")
         return answer
 
+def user_customizer(config: PromptTemplateInput[Any]) -> PromptTemplateInput[Any]:
+    """ user_customizer """
+
+    class UserSchema(BaseModel):
+        """ user schema"""
+        input: str
+
+    new_config = config.model_copy()
+    new_config.input_schema = UserSchema
+    new_config.template = """User: {{input}}"""
+    return new_config
+
+def no_result_customizer(config: PromptTemplateInput[Any]) -> PromptTemplateInput[Any]:
+    """ no_result_customizer """
+    new_config = config.model_copy()
+    config.template += """\nPlease reformat your input."""
+    return new_config
+
+def not_found_customizer(config: PromptTemplateInput[Any]) -> PromptTemplateInput[Any]:
+    """ not_found_customizer """
+    class ToolSchema(BaseModel):
+        """ Tool Schema """
+        name: str
+
+    class NotFoundSchema(BaseModel):
+        """ Not found schema """
+        tools: list[ToolSchema]
+
+    new_config = config.model_copy()
+    new_config.input_schema = NotFoundSchema
+    new_config.template = """Tool does not exist!
+{{#tools.length}}
+Use one of the following tools: {{#trim}}{{#tools}}{{name}},{{/tools}}{{/trim}}
+{{/tools.length}}"""
+    return new_config
+
+def user_template_func(template: PromptTemplateInput[Any]) -> PromptTemplateInput[Any]:
+    return template.fork(customizer=user_customizer)
+
+def system_template_func(template: PromptTemplateInput[Any], instructions: str) -> PromptTemplateInput[Any]:
+    return template.update(defaults={"instructions": instructions.strip()})
+
+def tool_no_result_error_template_func(template: PromptTemplateInput[Any]) -> PromptTemplateInput[Any]:
+    return template.fork(customizer=no_result_customizer)
+
+def tool_not_found_error_template_func(template: PromptTemplateInput[Any]) -> PromptTemplateInput[Any]:
+    return template.fork(customizer=not_found_customizer)
+
+def write(role: str, data: str) -> None:
+    """ write message """
+    print(f"{role} {data}")
+
+def process_agent_events(data: Any, event: EventMeta) -> None:
+    """Process agent events and log appropriately"""
+
+    if event.name == "error":
+        write("Agent 🤖 : ", FrameworkError.ensure(data.error).explain())
+    elif event.name == "success":
+        write("Agent 🤖 : ", "success")
+
+
+def observer(emitter: Emitter) -> None:
+    """Observer"""
+    emitter.on("*", process_agent_events, EmitterOptions(match_nested=False))
+
+class BeeAILocalAgent(Agent):
+    """
+    BeeAILocalAgent extends the Agent class to load and run a specific agent.
+    """
+
+    def __init__(self, agent: dict) -> None:
+        """
+        Initializes the workflow for the specified BeeAI agent.
+
+        Args:
+            agent_name (str): The name of the agent.
+        """
+        super().__init__(agent)
+
+        llm = OllamaChatModel(self.agent_model)
+
+        templates: dict[str, Any] = {
+            "user": lambda template: template.fork(customizer=user_customizer),
+            "system": lambda template: template.update(
+                defaults={"instructions": "You are a helpful assistant that uses tools to answer questions."}
+            ),
+            "tool_no_result_error": lambda template: template.fork(customizer=no_result_customizer),
+            "tool_not_found_error": lambda template: template.fork(customizer=not_found_customizer),
+        }
+
+        tools: list[AnyTool] = [
+            # WikipediaTool(),
+            OpenMeteoTool(),
+            DuckDuckGoSearchTool(),
+        ]
+
+        self.agent = ReActAgent(
+            llm=llm, templates=templates, tools=tools, memory=UnconstrainedMemory()
+        )
+
+    async def run(self, prompt: str) -> str:
+        """
+        Runs the BeeAI agent with the given prompt.
+        Args:
+            prompt (str): The prompt to run the agent with.
+        """
+
+        print(f"🐝 Running {self.agent_name}...\n")
+        response = await self.agent.run(
+            prompt=prompt,
+            execution=AgentExecutionConfig(
+                max_retries_per_step=3, total_max_retries=10,
+                max_iterations=20
+            ),
+            signal=AbortSignal.timeout(2 * 60 * 1000),
+        ).observe(observer)
+        answer = response.result.text
+        print(f"🐝 Response from {self.agent_name}: {answer}\n")
+        return answer
+
+    async def run_streaming(self, prompt: str) -> str:
+        """
+        Runs the agent in streaming mode with the given prompt.
+        Args:
+            prompt (str): The prompt to run the agent with.
+        """
+        print(f"🐝 Running {self.agent_name}...\n")
+        response = await self.agent.run(
+            prompt=prompt,
+            execution=AgentExecutionConfig(
+                max_retries_per_step=3,
+                total_max_retries=10,
+                max_iterations=20
+            ),
+            signal=AbortSignal.timeout(2 * 60 * 1000),
+        ).observe(observer)
+        answer = response.result.text
+        print(f"🐝 Response from {self.agent_name}: {answer}\n")
+        return answer

--- a/maestro/src/workflow.py
+++ b/maestro/src/workflow.py
@@ -18,7 +18,7 @@ import os, dotenv
 from src.mermaid import Mermaid
 
 from src.step import Step
-from src.agents.agent_factory import AgentFramework
+from src.agents.agent_factory import AgentFramework, AgentFactory
 
 from src.agents.crewai_agent import CrewAIAgent
 
@@ -33,7 +33,7 @@ from src.agents.agent import save_agent, restore_agent
 
 dotenv.load_dotenv() #TODO is this needed now that __init__.py in package runs this?
 
-def get_agent_class(framework: str) -> type:
+def get_agent_class(framework: str, mode="local") -> type:
     """
     Returns the agent class based on the provided framework.
 
@@ -45,14 +45,7 @@ def get_agent_class(framework: str) -> type:
     """
     if os.getenv("DRY_RUN"):
         return MockAgent
-    if framework == "crewai":
-        return CrewAIAgent
-    elif framework == "remote":
-        return RemoteAgent
-    elif framework == "beeailocal":
-        return BeeAILocalAgent
-    else:
-        return BeeAIAgent
+    return AgentFactory.create_agent(framework, mode)
 
 def create_agents(agent_defs):
     """
@@ -72,7 +65,7 @@ def create_agents(agent_defs):
         agent_def["spec"]["framework"] = agent_def["spec"].get(
             "framework", AgentFramework.BEEAI
         )
-        save_agent(get_agent_class(agent_def["spec"]["framework"])(agent_def))
+        save_agent(get_agent_class(agent_def["spec"]["framework"], agent_def["spec"].get("mode"))(agent_def))
 
 class Workflow:
     """Execute sequential workflow.
@@ -147,7 +140,7 @@ class Workflow:
                   agent_def["spec"]["framework"] = agent_def["spec"].get(
                       "framework", AgentFramework.BEEAI
                   )
-                  self.agents[agent_def["metadata"]["name"]] = get_agent_class(agent_def["spec"]["framework"])(agent_def)
+                  self.agents[agent_def["metadata"]["name"]] = get_agent_class(agent_def["spec"]["framework"], agent_def["spec"].get("mode"))(agent_def)
         else:
             for agent in workflow["spec"]["template"]["agents"]:
                 self.agents[agent] = restore_agent(agent)

--- a/maestro/tests/agents/beeai/agents.yaml
+++ b/maestro/tests/agents/beeai/agents.yaml
@@ -8,4 +8,4 @@ spec:
   model: "llama3.1:latest"
   description: test
   instructions: input = 'Mock agent:'
-  framework: bee
+  framework: beeai

--- a/maestro/tests/yamls/agents/funnier_agents.yaml
+++ b/maestro/tests/yamls/agents/funnier_agents.yaml
@@ -6,7 +6,7 @@ metadata:
     app: funnier-example
 spec:
   model: meta-llama/llama-3-1-70b-instruct
-  framework: bee
+  framework: beeai
   instructions: you are a joke telling agent
   description: this is a simple agent
   
@@ -19,6 +19,6 @@ metadata:
     app: funnier-example
 spec:
   model: meta-llama/llama-3-1-70b-instruct
-  framework: bee
+  framework: beeai
   instructions: you are a joke telling agent
   description: this is a simple agent

--- a/maestro/tests/yamls/agents/funnier_agents.yaml
+++ b/maestro/tests/yamls/agents/funnier_agents.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   model: meta-llama/llama-3-1-70b-instruct
   framework: beeai
+  mode: remote
   instructions: you are a joke telling agent
   description: this is a simple agent
   
@@ -20,5 +21,6 @@ metadata:
 spec:
   model: meta-llama/llama-3-1-70b-instruct
   framework: beeai
+  mode: remote
   instructions: you are a joke telling agent
   description: this is a simple agent

--- a/maestro/tests/yamls/agents/funnier_local_agents.yaml
+++ b/maestro/tests/yamls/agents/funnier_local_agents.yaml
@@ -6,7 +6,8 @@ metadata:
     app: funnier-example
 spec:
   model: llama3.1
-  framework: beeailocal
+  mode: local
+  framework: beeai
   instructions: you are a joke telling agent
   description: this is a simple agent
   
@@ -19,6 +20,7 @@ metadata:
     app: funnier-example
 spec:
   model: llama3.1
-  framework: beeailocal
+  framework: beeai
+  mode: local
   instructions: you are a joke telling agent
   description: this is a simple agent

--- a/maestro/tests/yamls/agents/simple_agent.yaml
+++ b/maestro/tests/yamls/agents/simple_agent.yaml
@@ -6,7 +6,7 @@ metadata:
     app: test-example
 spec:
   model: meta-llama/llama-3-1-70b-instruct
-  framework: bee
+  framework: beeai
   description: this is a test
   tools:
     - code_interpreter
@@ -23,7 +23,7 @@ metadata:
     app: test-example
 spec:
   model: meta-llama/llama-3-1-70b-instruct
-  framework: bee
+  framework: beeai
   description: this is a test
   tools:
     - code_interpreter
@@ -40,7 +40,7 @@ metadata:
     app: test-example
 spec:
   model: meta-llama/llama-3-1-70b-instruct
-  framework: bee
+  framework: beeai
   description: this is a test
   tools:
     - code_interpreter
@@ -57,7 +57,7 @@ metadata:
     app: test-example
 spec:
   model: meta-llama/llama-3-1-70b-instruct
-  framework: bee
+  framework: beeai
   description: this is a test
   tools:
     - code_interpreter
@@ -74,7 +74,7 @@ metadata:
     app: test-example
 spec:
   model: meta-llama/llama-3-1-70b-instruct
-  framework: bee
+  framework: beeai
   description: this is a test
   tools:
     - code_interpreter

--- a/maestro/tests/yamls/agents/simple_agent.yaml
+++ b/maestro/tests/yamls/agents/simple_agent.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   model: meta-llama/llama-3-1-70b-instruct
   framework: beeai
+  mode: remote
   description: this is a test
   tools:
     - code_interpreter
@@ -24,6 +25,7 @@ metadata:
 spec:
   model: meta-llama/llama-3-1-70b-instruct
   framework: beeai
+  mode: remote
   description: this is a test
   tools:
     - code_interpreter
@@ -41,6 +43,7 @@ metadata:
 spec:
   model: meta-llama/llama-3-1-70b-instruct
   framework: beeai
+  mode: remote
   description: this is a test
   tools:
     - code_interpreter
@@ -58,6 +61,7 @@ metadata:
 spec:
   model: meta-llama/llama-3-1-70b-instruct
   framework: beeai
+  mode: remote
   description: this is a test
   tools:
     - code_interpreter
@@ -75,6 +79,7 @@ metadata:
 spec:
   model: meta-llama/llama-3-1-70b-instruct
   framework: beeai
+  mode: remote
   description: this is a test
   tools:
     - code_interpreter

--- a/maestro/tests/yamls/agents/simple_local_agent.yaml
+++ b/maestro/tests/yamls/agents/simple_local_agent.yaml
@@ -5,9 +5,10 @@ metadata:
   labels:
     app: test-example
 spec:
-  # model: meta-llama/llama-3-1-70b-instruct
+
   model: llama3.1
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: this is a test
   tools:
     - code_interpreter
@@ -23,9 +24,9 @@ metadata:
   labels:
     app: test-example
 spec:
-  # model: meta-llama/llama-3-1-70b-instruct
   model: llama3.1
-  framework: beeailocal
+  mode: local
+  framework: beeai
   description: this is a test
   tools:
     - code_interpreter
@@ -41,9 +42,9 @@ metadata:
   labels:
     app: test-example
 spec:
-  # model: meta-llama/llama-3-1-70b-instruct
   model: llama3.1
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: this is a test
   tools:
     - code_interpreter
@@ -59,9 +60,9 @@ metadata:
   labels:
     app: test-example
 spec:
-  # model: meta-llama/llama-3-1-70b-instruct
   model: llama3.1
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: this is a test
   tools:
     - code_interpreter
@@ -77,9 +78,9 @@ metadata:
   labels:
     app: test-example
 spec:
-  # model: meta-llama/llama-3-1-70b-instruct
   model: llama3.1
-  framework: beeailocal
+  framework: beeai
+  mode: local
   description: this is a test
   tools:
     - code_interpreter


### PR DESCRIPTION
fix 
>streamline BeeAI (local and remote) -- should be one YAML with framework and mode (local or remote) and factory can use that to create the right instance
in #384 

Setting "remote" in `spec.mode` uses the "remote" agent.  The default (`spec.mode` is not set) is the local agent.