### PR TITLE
Add module, class and factory in meta.labels

### DIFF
--- a/maestro/demos/agents/crewai/activity_planner/activity_planner.py
+++ b/maestro/demos/agents/crewai/activity_planner/activity_planner.py
@@ -65,7 +65,7 @@ class ActivityPlannerCrew:
             config=self.agents_config["activity_planner_agent"],
             # tools=[self.ddg_search],  # Include the DuckDuckGo search tool
             llm=self.llm,  # Use the locally running LLM (Ollama 3.1)
-            verbose=True,
+            verbose=False,
         )
 
     @task
@@ -92,7 +92,7 @@ class ActivityPlannerCrew:
             tasks=self.tasks,
             process=Process.sequential,
             # TODO: disable verbose when working well
-            verbose=True,
+            verbose=False,
         )
 
 # Main for testing

--- a/maestro/demos/workflows/activity-planner-crewai.ai/agents.yaml
+++ b/maestro/demos/workflows/activity-planner-crewai.ai/agents.yaml
@@ -1,13 +1,14 @@
 apiVersion: maestro/v1alpha1
 kind: Agent
 metadata:
-  name: demos.agents.crewai.activity_planner.activity_planner.ActivityPlannerCrew.activity_crew
+  name: ActivityPlannerCrew
   labels:
     app: activity-planner-demo
+    module: demos.agents.crewai.activity_planner.activity_planner
+    class: ActivityPlannerCrew
+    factory: activity_crew
 spec:
   model: "llama3.1:latest"
-  framework: beeai
-  mode: remote
   description: test
   instructions: Nothing to do
   framework: crewai

--- a/maestro/demos/workflows/activity-planner-crewai.ai/workflow.yaml
+++ b/maestro/demos/workflows/activity-planner-crewai.ai/workflow.yaml
@@ -10,8 +10,8 @@ spec:
       labels:
         app: activity-planner-demo
     agents:
-      - demos.agents.crewai.activity_planner.activity_planner.ActivityPlannerCrew.activity_crew
+      - ActivityPlannerCrew
     prompt: Show me some activities to do in London in cold weather
     steps:
       - name: begin
-        agent: demos.agents.crewai.activity_planner.activity_planner.ActivityPlannerCrew.activity_crew
+        agent: ActivityPlannerCrew

--- a/maestro/src/agents/crewai_agent.py
+++ b/maestro/src/agents/crewai_agent.py
@@ -26,8 +26,9 @@ class CrewAIAgent(Agent):
         #   test.crewai_test.ColdWeatherCrew.activity_crew
 
         try:
-            partial_agent_name, self.method_name = self.agent_name.rsplit(".", 1)
-            self.module_name, self.class_name = partial_agent_name.rsplit(".", 1)
+            self.module_name = agent["metadata"]["labels"]["module"]
+            self.class_name = agent["metadata"]["labels"]["class"]
+            self.factory_name = agent["metadata"]["labels"]["factory"]
         except Exception as e:
             print(f"🧑🏽‍✈️ Failed to load agent {self.agent_name}: {e}")
             raise(e)
@@ -52,8 +53,8 @@ class CrewAIAgent(Agent):
             self.crew_agent_class = getattr(my_module, self.class_name)
             # Instantiate the class
             self.instance = self.crew_agent_class()
-            method = getattr(self.instance, self.method_name)
-            output = method().kickoff({ 'prompt': prompt})
+            factory = getattr(self.instance, self.factory_name)
+            output = factory().kickoff({ 'prompt': prompt})
             return { 'prompt': output.raw }
 
         # TODO address error handling

--- a/maestro/tests/agents/crewai_agent/agents.yaml
+++ b/maestro/tests/agents/crewai_agent/agents.yaml
@@ -1,9 +1,12 @@
 apiVersion: maestro/v1alpha1
 kind: Agent
 metadata:
-  name: tests.agents.crewai_agent.crew_dummy.DummyCrew.dummy_crew
+  name: DummyCrew
   labels:
     app: crewaitest
+    module: tests.agents.crewai_agent.crew_dummy
+    class: DummyCrew
+    factory: dummy_crew
 spec:
   model: "llama3.1:latest"
   description: test

--- a/maestro/tests/agents/crewai_agent/workflow.yaml
+++ b/maestro/tests/agents/crewai_agent/workflow.yaml
@@ -10,8 +10,8 @@ spec:
       labels:
         app: crewaitest
     agents:
-      - tests.agents.crewai_agent.crew_dummy.DummyCrew.dummy_crew
+      - DummyCrew
     prompt: Show me some activities to do in London in the cold weather
     steps:
       - name: begin
-        agent: tests.agents.crewai_agent.crew_dummy.DummyCrew.dummy_crew
+        agent: DummyCrew


### PR DESCRIPTION
Move "module", "class" and "factory" in `meta.name` to `meta.labels` so that the name can have any string