### PR TITLE
fixes issue #306 by adding --prompt to run command

### DIFF
--- a/maestro/cli/commands.py
+++ b/maestro/cli/commands.py
@@ -225,6 +225,8 @@ class RunCmd(Command):
         self.args = args
         super().__init__(self.args)
 
+    # private
+
     def __run_agents_workflow(self, agents_yaml, workflow_yaml):
         try:
             workflow = Workflow(agents_yaml, workflow_yaml[0])
@@ -233,12 +235,20 @@ class RunCmd(Command):
             self._check_verbose()
             raise RuntimeError(f"{str(e)}") from e
         return 0
-    
+
+    def __read_prompt(self):
+        return Console.read('Enter your prompt: ')
+
+    # public
+
     def AGENTS_FILE(self):
         return self.args['AGENTS_FILE']
 
     def WORKFLOW_FILE(self):
         return self.args['WORKFLOW_FILE']
+
+    def prompt(self):
+        return self.args.get('--prompt')
 
     def name(self):
       return "run"
@@ -248,6 +258,11 @@ class RunCmd(Command):
         if self.AGENTS_FILE() != None and self.AGENTS_FILE() != 'None':
             agents_yaml = parse_yaml(self.AGENTS_FILE())
         workflow_yaml = parse_yaml(self.WORKFLOW_FILE())
+
+        if self.prompt():
+            prompt = self.__read_prompt()
+            workflow_yaml[0]['spec']['template']['prompt'] = prompt
+
         try:
             self.__run_agents_workflow(agents_yaml, workflow_yaml)
         except Exception as e:

--- a/maestro/cli/common.py
+++ b/maestro/cli/common.py
@@ -47,6 +47,9 @@ def read_file(file_path):
         Console.error("Could read file: {file_path}")
 
 class Console:
+    def read(message):
+        return input(message)
+
     def verbose(msg):
         if VERBOSE:
             print(f"{Colors.OKBLUE}{msg}{Colors.ENDC}".format(msg=str(msg)))

--- a/maestro/cli/maestro.py
+++ b/maestro/cli/maestro.py
@@ -33,6 +33,7 @@ Options:
   --verbose              Show all output.
   --silent               Show no additional output on success, e.g., no OK or Success etc
   --dry-run              Mocks agents and other parts of workflow execution.
+  --prompt               Reads a user prompt and executes workflow with it
   --auto-prompt          Run prompt by default if specified
 
   --streamlit            Deploys locally as streamlit application (default deploy)

--- a/maestro/tests/cli/test_commands.py
+++ b/maestro/tests/cli/test_commands.py
@@ -16,7 +16,7 @@
 
 import os
 import unittest
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from cli.commands import CLI
 
@@ -115,6 +115,7 @@ class RunCommandTest(TestCommand):
                         '--dry-run': True,
                         '--help': False,
                         '--verbose': False,
+                        '--prompt': False,
                         '--silent': False,
                         '--version': False,
                         'AGENTS_FILE': self.get_fixture('yamls/agents/simple_agent.yaml'),
@@ -131,13 +132,22 @@ class RunCommandTest(TestCommand):
     def tearDown(self):
         self.args = {}
         self.command = None
-        
+
     def test_run__dry_run(self):
         self.assertTrue(self.command.name() == 'run')
         try:
             self.command.execute()
         except Exception as e:
             self.fail(f"Exception running command: {str(e)}")
+
+    def test_run__dry_run_prompt(self):
+        with mock.patch('builtins.input', return_value='test prompt'):
+            self.args['--prompt'] = True
+            self.assertTrue(self.command.name() == 'run')
+            try:
+                self.command.execute()
+            except Exception as e:
+                self.fail(f"Exception running command: {str(e)}")
 
     def test_run_None_agents_file__dry_run(self):
         self.args['AGENTS_FILE'] = None


### PR DESCRIPTION
This PR solves issue #306 by adding `--prompt` for run commands:

```bash
maestro git:(main) ./maestro run ./tests/yamls/agents/simple_agent.yaml ./tests/yamls/workflows/simple_workflow.yaml --prompt --verbose --dry-run
Enter your prompt: lol
Mock agent:Loading code_interpreter
[...]
🤖 Response from test3: lol
```