### PR TITLE
Add MCP tool support

### DIFF
--- a/maestro/pyproject.toml
+++ b/maestro/pyproject.toml
@@ -26,6 +26,8 @@ openapi = "^2.0.0"
 openai-agents = "^0.0.11"
 pycron = "^3.1.2"
 beeai-framework = "^0.1.17"
+pytest-asyncio = "^0.26.0"
+mcp = "^1.6.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.10.0"

--- a/maestro/src/agents/mcp_tools.py
+++ b/maestro/src/agents/mcp_tools.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import httpx
+from typing import List, Dict, Any, Optional, Tuple, AsyncGenerator
+import traceback
+from contextlib import asynccontextmanager 
+
+# TODO: Resilient model loading - import errors during dev (wrong lib)- keep or remove?
+try:
+    from mcp.client.sse import sse_client
+    from mcp.client.session import ClientSession
+    mcp_enabled = True
+    MCP_IMPORT_ERROR = None
+except ImportError as e:
+    print(f"WARNING: Could not import MCP components (sse_client, ClientSession). MCP tool support will be disabled. Run `poetry sync` or `pip install mcp`? Error: {e}")
+    mcp_enabled = False
+    MCP_IMPORT_ERROR = e
+    # Dummies for import failure (to avoid warnings from type safety checks)
+    def sse_client(*args, **kwargs): pass
+    class ClientSession: pass
+
+# TODO: Needs to be retrieved from config. For now this is default fastmcp on localhost
+DEFAULT_MCP_ENDPOINTS: List[str] = [
+    "http://localhost:8000/sse",
+]
+
+# TODO: Utility function - helped to locate issues during development. Keep, move, or remove?
+def _log_exception_details(e: Exception, context_msg: str = ""):
+    """Logs details of an exception, including nested ExceptionGroups."""
+    print(f"MCPToolManager: {context_msg}: {type(e).__name__} - {e}")
+
+    def print_group(exc_group, indent=0):
+        prefix = "  " * indent
+        if not isinstance(exc_group, ExceptionGroup):
+            print(f"{prefix}Cause: {type(exc_group).__name__} - {exc_group}")
+            print(f"{prefix}Traceback:")
+            tb_lines = traceback.format_exception(type(exc_group), exc_group, exc_group.__traceback__)
+            for line in tb_lines:
+                print(f"{prefix}  {line.strip()}")
+            return
+        print(f"{prefix}ExceptionGroup Message: {exc_group.message}")
+        for i, sub_exc in enumerate(exc_group.exceptions):
+            print(f"{prefix}Sub-exception {i+1}/{len(exc_group.exceptions)}:")
+            print_group(sub_exc, indent + 1)
+
+    if isinstance(e, ExceptionGroup):
+        print_group(e)
+    else:
+        print("Traceback:")
+        traceback.print_exc()
+
+
+class MCPToolManager:
+    """
+    Manages discovery and interaction with tools via the Model Context Protocol (MCP).
+    Uses sse_client context manager for remote access to MCP servers.
+    Local access via STDIO is not supported.
+    """
+    endpoints: List[str]
+    # Save tool info
+    tools: Dict[str, Tuple[Any, str]]
+    openai_tools_schemas: Dict[str, Dict[str, Any]]
+
+    def __init__(self, endpoints: Optional[List[str]] = None):
+        """Initializes the MCPToolManager."""
+        self.endpoints = []
+        self.tools = {}
+        self.openai_tools_schemas = {}
+        if not mcp_enabled:
+            print(f"MCPToolManager disabled due to import error: {MCP_IMPORT_ERROR}")
+            return
+        self.endpoints = endpoints if endpoints is not None else DEFAULT_MCP_ENDPOINTS
+        print(f"MCPToolManager initialized with endpoints: {self.endpoints}")
+
+    @asynccontextmanager
+    async def _get_mcp_session(self, endpoint_url: str) -> AsyncGenerator[ClientSession, None]:
+        """Async context manager to connect and yield an initialized MCP session."""
+        print(f"MCPToolManager: Connecting via SSE to {endpoint_url}...")
+        async with sse_client(endpoint_url) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
+
+    async def discover_tools(self) -> None:
+        """Connects to configured MCP endpoints and discovers available tools."""
+        # TODO: This does a fair amount of printing - for library method this probably should be debug only
+        if not mcp_enabled:
+            print("MCPToolManager: MCP support disabled, skipping discovery.")
+            return
+        if not self.endpoints:
+            print("MCPToolManager: No MCP endpoints configured, skipping discovery.")
+            return
+
+        print("MCPToolManager: Starting tool discovery...")
+        self.tools = {}
+        self.openai_tools_schemas = {}
+        discovery_tasks = [self._discover_endpoint(endpoint) for endpoint in self.endpoints]
+        results = await asyncio.gather(*discovery_tasks, return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                pass # Already logged
+
+        print("MCPToolManager: Tool discovery finished.")
+        if not self.tools:
+            print("MCPToolManager: No tools discovered.")
+        else:
+            print("MCPToolManager: Discovered tools:")
+            for name, (tool, endpoint) in self.tools.items():
+                print(f"  - Name: {name}")
+                print(f"    Description: {getattr(tool, 'description', 'N/A')}")
+                print(f"    Endpoint: {endpoint}")
+                print(f"    OpenAI Schema: {self.openai_tools_schemas.get(name)}")
+
+    async def _discover_endpoint(self, endpoint_url: str) -> None:
+        """Helper to discover tools from a single endpoint."""
+        if not mcp_enabled: return
+
+        try:
+            async with self._get_mcp_session(endpoint_url) as session:
+                print(f"MCPToolManager: Discovering tools using session for {endpoint_url}...")
+                response = await session.list_tools()
+                # TODO: should be a .tools attribute (empirically determined) - is this correct way?
+                discovered: List[Any] = getattr(response, 'tools', [])
+
+                if not discovered:
+                    print(f"MCPToolManager: No tools found at {endpoint_url}.")
+                    return
+
+                for tool in discovered:
+                    tool_name = getattr(tool, 'name', None)
+                    if not tool_name:
+                        print(f"MCPToolManager: Warning - Discovered tool at {endpoint_url} is missing a 'name'. Skipping.")
+                        continue
+                    if tool_name in self.tools:
+                        print(f"MCPToolManager: Warning - Duplicate tool name '{tool_name}' found at {endpoint_url}. Overwriting previous definition from {self.tools[tool_name][1]}.")
+
+                    # Store the tool object itself for later use
+                    self.tools[tool_name] = (tool, endpoint_url)
+                    self.openai_tools_schemas[tool_name] = self._convert_to_openai_tool(tool)
+                    print(f"MCPToolManager: Discovered tool '{tool_name}' at {endpoint_url}")
+
+        except httpx.RequestError as e:
+            print(f"MCPToolManager: Error connecting via SSE to {endpoint_url}: {e}")
+            raise
+        except Exception as e:
+            _log_exception_details(e, f"Error during SSE discovery at {endpoint_url}")
+            raise # Exception as we are initializing ?
+
+    # TODO: Needed to call from OpenAI - keep here, or in openai module?
+    def _convert_to_openai_tool(self, tool: Any) -> Dict[str, Any]:
+        """Converts an MCP Tool object (duck-typed) to the OpenAI tool format."""
+        tool_name = getattr(tool, 'name', 'unknown_tool')
+        description = getattr(tool, 'description', None)
+        # Should be 'inputSchema' based on docs, fallback to 'parameters'
+        parameters = getattr(tool, 'inputSchema', getattr(tool, 'parameters', None))
+        return {
+            "type": "function",
+            "function": {
+                "name": tool_name,
+                "description": description or f"MCP tool: {tool_name}",
+                "parameters": parameters or {"type": "object", "properties": {}},
+            },
+        }
+
+    def get_openai_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Returns a list of discovered tools formatted for the OpenAI API."""
+        return list(self.openai_tools_schemas.values())
+
+    def is_mcp_tool(self, tool_name: str) -> bool:
+        """Checks if a tool name corresponds to a discovered MCP tool."""
+        return tool_name in self.tools
+
+    async def execute_tool_streaming(self, tool_name: str, arguments: Dict[str, Any]) -> Optional[Any]:
+        """Executes a discovered MCP tool."""
+        if not mcp_enabled:
+            print("MCPToolManager: Cannot execute tool, MCP support disabled.")
+            return None
+        if tool_name not in self.tools:
+            print(f"MCPToolManager: Error - Attempted to execute unknown tool '{tool_name}'.")
+            return None
+
+        tool, endpoint_url = self.tools[tool_name]
+        print(f"MCPToolManager: Executing tool '{tool_name}' via SSE to {endpoint_url} with args: {arguments}")
+        final_tool_result: Any = None
+
+        try:
+            async with self._get_mcp_session(endpoint_url) as session:
+                print(f"MCPToolManager: Calling tool '{tool_name}' using session for {endpoint_url}...")
+                final_tool_result = await session.call_tool(
+                    name=tool_name,
+                    arguments=arguments,
+                )
+                print(f"MCPToolManager: Received result object for '{tool_name}': {final_tool_result!r}")
+
+            print(f"MCPToolManager: Finished execution for '{tool_name}'.")
+            # TODO: Every tool will return something different - consider how to handle better
+            return {
+                "status": "success",
+                "message": f"Tool '{tool_name}' executed.",
+                "raw_result": final_tool_result
+            }
+
+        # TODO: If something goes wrong, do we reraise exception, or just return None - safer??
+        except httpx.RequestError as e:
+            print(f"MCPToolManager: Error connecting via SSE to {endpoint_url} for tool execution: {e}")
+            return None
+        except Exception as e:
+            _log_exception_details(e, f"Error during SSE tool execution at {endpoint_url}")
+            return None

--- a/maestro/src/agents/openai_agent.py
+++ b/maestro/src/agents/openai_agent.py
@@ -1,3 +1,4 @@
+# src/agents/openai_agent.py
 # Copyright © 2025 IBM
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,65 +24,108 @@ from agents import (
     set_tracing_disabled,
 )
 from src.agents.agent import Agent
+from typing import List, Dict, Any, AsyncIterator, Optional # Added Optional
+import asyncio # Added for gather
+
+# Import the MCP Tool Manager
+from .mcp_tools import MCPToolManager, mcp_enabled # Import mcp_enabled flag too
 
 class OpenAIAgent(Agent):
     """
-    OpenAI extends the Agent class to load and run a agent using OpenAI.
+    OpenAI extends the Agent class to load and run a agent using OpenAI,
+    supporting both standard and streaming responses via the Chat Completions API,
+    and potentially utilizing MCP tools.
     """
+    client: OAIAsyncOpenAI
+    model_name: str
+    openai_agent: OAIAgent # Instance of the Agent class from the 'agents' library
+    agent_id: str
+    mcp_tool_manager: Optional[MCPToolManager] # Add MCP tool manager instance variable
+    openai_mcp_tools: List[Dict[str, Any]] # Store formatted tools for OpenAI API
+
     def __init__(self, agent: dict) -> None:
         """
         Initializes the workflow for the specified OpenAI agent.
+        Also initializes MCP tool discovery if enabled.
 
         Args:
             agent_name (str): The name of the agent.
         """
         super().__init__(agent)
-        
-        # TODO: Add tools (std and MCP)
 
-        # TODO : for now we use environment variables - set to http://localhost:11434/v1 for Ollama
-        base_url = os.getenv("OPENAI_BASE_URL","https://api.openai.com/v1")
-        api_key = os.getenv("OPENAI_API_KEY")
-        spec_dict = agent.get('spec', {})
-        model_name: str = spec_dict.get('model', "gpt-4o-mini")
+        # --- OpenAI Client Setup (existing code) ---
+        base_url: str = os.getenv("OPENAI_BASE_URL","https://api.openai.com/v1")
+        api_key: str | None = os.getenv("OPENAI_API_KEY")
+        spec_dict: Dict[str, Any] = agent.get('spec', {})
+        self.model_name = spec_dict.get('model', "gpt-4o-mini")
 
-        # TODO: Proper debug
-        self.print(f"DEBUG [OpenAIAgent {self.agent_name}]: Using Base URL: {base_url}")
-        self.print(f"DEBUG [OpenAIAgent {self.agent_name}]: Using Model: {model_name}")
-        
-        client = OAIAsyncOpenAI(
+        print(f"DEBUG [OpenAIAgent {self.agent_name}]: Using Base URL: {base_url}")
+        print(f"DEBUG [OpenAIAgent {self.agent_name}]: Using Model: {self.model_name}")
+
+        self.client = OAIAsyncOpenAI(
             base_url=base_url,
             api_key=api_key,
         )
-        # Update the parms for the endpoint. Tracing uses OpenAI backend, so disable tracing too
-        set_default_openai_client(client=client, use_for_tracing=False)
-        # For now, use the chat completions api, even for OpenAI
+        set_default_openai_client(client=self.client, use_for_tracing=False)
         set_default_openai_api("chat_completions")
         set_tracing_disabled(disabled=True)
+
+        # Get tools available from mcp
+        self.mcp_tool_manager = None
+        self.openai_mcp_tools = []
+        if mcp_enabled:
+            # TODO: Pass endpoints from config if needed, otherwise uses defaults
+            self.mcp_tool_manager = MCPToolManager()
+            # Note: Discovery is async, needs to be run in an event loop.
+            # We'll trigger it before the first run if not already done.
+            # Or, ideally, initialize it asynchronously if the main app structure allows.
+            # For now, let's plan to call it within the run methods.
+            print(f"DEBUG [OpenAIAgent {self.agent_name}]: MCP Tool Manager initialized.")
+            print(f"DEBUG [OpenAIAgent {self.agent_name}]: Triggering MCP tool discovery...")
+            # TODO - Async function to sort
+            self.mcp_tool_manager.discover_tools()
+            self.openai_mcp_tools = self.mcp_tool_manager.get_openai_tool_schemas()
+            print(f"DEBUG [OpenAIAgent {self.agent_name}]: MCP tools ready for OpenAI API: {len(self.openai_mcp_tools)}")
+        else:
+            print(f"DEBUG [OpenAIAgent {self.agent_name}]: MCP Tool Manager disabled.")
         
         self.openai_agent = OAIAgent(
             name=self.agent_name,
             instructions=self.instructions,
-            model=model_name
-            )
-
+            model=self.model_name,
+            # TODO: Agent SDK does not support MCP Tools ! (FATAL)
+            tools=self.openai_mcp_tools,
+        )
+        
         self.agent_id=self.agent_name
-    
+
+
     async def run(self, prompt: str) -> str:
+        """
+        Runs the agent with the given prompt using Chat Completions (non-streaming).
+        Includes discovered MCP tools in the API call if available.
+
+        Args:
+            prompt (str): The prompt to run the agent with.
+        Returns:
+            str: The content of the response message or an error string.
+        """
+
         """
         Runs the agent with the given prompt.
         Args:
             prompt (str): The prompt to run the agent with.
         """
         self.print(f"Running {self.agent_name}...")
-        result = await OAIRunner.run(self.openai_agent, prompt)        
+        result = await OAIRunner.run(self.openai_agent, prompt)
         self.print(f"Response from {self.agent_name}: {result.final_output}")
         return result.final_output
+
 
     async def run_streaming(self, prompt: str) -> str:
         """
         Runs the agent in streaming mode with the given prompt.
         Args:
             prompt (str): The prompt to run the agent with.
-        """        
+        """
         return await self.run(prompt)

--- a/maestro/tests/mcp/test_mcp_tools.py
+++ b/maestro/tests/mcp/test_mcp_tools.py
@@ -1,0 +1,212 @@
+# tests/mcp/test_mcp_tools.py
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import sys
+import os
+from typing import Dict, Any, AsyncGenerator, List
+
+import pytest
+import pytest_asyncio
+
+try:
+    from src.agents.mcp_tools import MCPToolManager, mcp_enabled, DEFAULT_MCP_ENDPOINTS
+except ImportError as e:
+    print(f"ERROR: Failed to import MCPToolManager. Make sure project structure is correct and contains 'src/agents/mcp_tools.py'.")
+    print(f"Import Error: {e}")
+    MCPToolManager = None
+    mcp_enabled = False
+    DEFAULT_MCP_ENDPOINTS = []
+
+
+@pytest_asyncio.fixture(scope="module")
+async def mcp_manager() -> AsyncGenerator[MCPToolManager, None]:
+    """
+    Pytest fixture to initialize and yield the MCPToolManager.
+    Performs initial checks and discovery once per module.
+    Skips tests if MCP is disabled or no endpoints are configured.
+    """
+    print("\n--- Setting up MCPToolManager Fixture ---")
+    if not mcp_enabled:
+        pytest.skip("MCP library ('mcp') not installed or failed to import. Did you 'pip install mcp'? Skipping MCP tests.")
+
+    if not DEFAULT_MCP_ENDPOINTS:
+        pytest.skip("No MCP endpoints configured in DEFAULT_MCP_ENDPOINTS (in mcp_tools.py). Skipping MCP tests.")
+
+    # TODO: For testing, consider what MCP server is used
+    print(f"Fixture: Using MCP endpoints: {DEFAULT_MCP_ENDPOINTS}")
+    manager = MCPToolManager()
+
+    print("Fixture: Discovering tools...")
+    try:
+        await manager.discover_tools() # Discover tools once for the module
+        if not manager.tools:
+            print("Fixture: WARNING - No tools discovered during setup (check endpoints and server status).")
+        else:
+            print(f"Fixture: Discovered {len(manager.tools)} tools.")
+    except Exception as e:
+        pytest.fail(f"Fixture: FAILED - An unexpected error occurred during tool discovery: {e}", pytrace=False)
+
+    yield manager # Provide the initialized manager (with discovered tools) to tests
+
+    print("\n--- Tearing down MCPToolManager Fixture ---")
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_discovery(mcp_manager: MCPToolManager):
+    """
+    Tests if the MCPToolManager discovered any tools.
+    Relies on the fixture having already run discover_tools().
+    """
+    print("\n--- Running Pytest: Tool Discovery Check ---")
+    assert mcp_manager is not None
+    if mcp_manager.tools:
+        print(f"Pytest Discovery Check: PASSED (Fixture found {len(mcp_manager.tools)} tools)")
+    else:
+        print("Pytest Discovery Check: COMPLETED (Fixture found no tools)")
+
+
+@pytest.mark.asyncio
+async def test_mcp_basic_tool_execution(mcp_manager: MCPToolManager):
+    """
+    Tests executing the first discovered MCP tool with dummy arguments using Pytest.
+    Skips if no tools were discovered by the fixture.
+    """
+    print("\n--- Running Pytest: Basic Tool Execution ---")
+    if not mcp_manager.tools:
+        pytest.skip("Skipping execution test because no tools were discovered during fixture setup.")
+
+    first_tool_name = list(mcp_manager.tools.keys())[0]
+    tool, endpoint = mcp_manager.tools[first_tool_name]
+    print(f"Pytest: Attempting to execute the first discovered tool: '{first_tool_name}' from {endpoint}")
+    print(f"Pytest: Tool Description: {getattr(tool, 'description', 'N/A')}")
+
+    # Determine Dummy Args based on Schema
+    schema = getattr(tool, 'inputSchema', getattr(tool, 'parameters', {}))
+    required_params = schema.get('required', []) if isinstance(schema, dict) else []
+    properties = schema.get('properties', {}) if isinstance(schema, dict) else {}
+    dummy_args: Dict[str, Any] = {}
+
+    print(f"Pytest: Generating dummy arguments based on schema (required: {required_params})")
+    for param_name in required_params:
+        param_info = properties.get(param_name, {})
+        param_type = param_info.get('type', 'string')
+        if param_type == 'integer' or param_type == 'number':
+            dummy_args[param_name] = 0
+        elif param_type == 'boolean':
+            dummy_args[param_name] = False
+        elif param_type == 'array':
+            dummy_args[param_name] = []
+        elif param_type == 'object':
+            dummy_args[param_name] = {}
+        else: # Default to string
+            dummy_args[param_name] = f"dummy_{param_name}"
+        print(f"  - Added dummy arg: {param_name}={dummy_args[param_name]}")
+
+    print(f"Pytest: Using generated dummy arguments: {dummy_args}")
+
+    try:
+        result = await mcp_manager.execute_tool_streaming(first_tool_name, dummy_args)
+        print(f"\nPytest Execution Test: FINISHED for tool '{first_tool_name}'.")
+        if result:
+            print(f"  Pytest Final Result (Placeholder/Accumulated): {result}")
+            assert result is not None
+            assert isinstance(result, dict)
+            assert "status" in result
+        else:
+            print("  Pytest Execution returned None or empty result (check logs).")
+            # TODO: Consider failing if None is unexpected
+            # pytest.fail("Tool execution returned None unexpectedly.")
+
+    except Exception as e:
+        print(f"\nPytest Execution Test: FAILED - An unexpected error occurred during execution of '{first_tool_name}': {e}")
+        pytest.fail(f"Unexpected exception during tool execution: {e}", pytrace=False)
+
+
+async def run_standalone_tests():
+    """Runs the MCP tool checks as a standalone script."""
+    print("--- Starting MCP Tool Manager Test (Standalone) ---")
+
+    if not mcp_enabled:
+        print("MCP library ('mcp') not installed or failed to import. Did you 'pip install mcp'?")
+        print("Skipping MCP tests.")
+        print("--- MCP Tool Manager Test Finished (Skipped) ---")
+        return
+
+    print(f"Standalone: Attempting to connect to MCP endpoints: {DEFAULT_MCP_ENDPOINTS}")
+    if not DEFAULT_MCP_ENDPOINTS:
+        print("\nStandalone WARNING: No MCP endpoints configured in DEFAULT_MCP_ENDPOINTS (in mcp_tools.py).")
+        print("Please add your MCP server URLs to test discovery and execution.")
+        print("--- MCP Tool Manager Test Finished (No Endpoints) ---")
+        return
+
+    manager = MCPToolManager()
+
+    print("\n--- Standalone Test 1: Discovering Tools ---")
+    try:
+        await manager.discover_tools()
+        if manager.tools:
+            print("\nStandalone Discovery Test: SUCCESS - Found one or more tools.")
+        else:
+            print("\nStandalone Discovery Test: FINISHED - No tools were discovered (check endpoints and server status).")
+    except Exception as e:
+        print(f"\nStandalone Discovery Test: FAILED - An unexpected error occurred: {e}")
+        print("--- MCP Tool Manager Test Finished (Error) ---")
+        return
+
+    print("\n--- Standalone Test 2: Attempting Basic Tool Execution ---")
+    if not manager.tools:
+        print("Standalone: Skipping execution test because no tools were discovered.")
+    else:
+        first_tool_name = list(manager.tools.keys())[0]
+        tool, endpoint = manager.tools[first_tool_name]
+        print(f"Standalone: Attempting to execute: '{first_tool_name}' from {endpoint}")
+        print(f"Standalone: Tool Description: {getattr(tool, 'description', 'N/A')}")
+
+        # Determine Dummy Args based on Schema (Standalone)
+        schema = getattr(tool, 'inputSchema', getattr(tool, 'parameters', {}))
+        required_params = schema.get('required', []) if isinstance(schema, dict) else []
+        properties = schema.get('properties', {}) if isinstance(schema, dict) else {}
+        dummy_args: Dict[str, Any] = {}
+
+        print(f"Standalone: Generating dummy arguments based on schema (required: {required_params})")
+        for param_name in required_params:
+            param_info = properties.get(param_name, {})
+            param_type = param_info.get('type', 'string')
+            if param_type == 'integer' or param_type == 'number':
+                dummy_args[param_name] = 0
+            elif param_type == 'boolean':
+                dummy_args[param_name] = False
+            elif param_type == 'array':
+                dummy_args[param_name] = []
+            elif param_type == 'object':
+                dummy_args[param_name] = {}
+            else:
+                dummy_args[param_name] = f"dummy_{param_name}"
+            print(f"  - Added dummy arg: {param_name}={dummy_args[param_name]}")
+
+        print(f"Standalone: Using generated dummy arguments: {dummy_args}")
+
+        try:
+            result = await manager.execute_tool_streaming(first_tool_name, dummy_args)
+            print(f"\nStandalone Execution Test: FINISHED for tool '{first_tool_name}'.")
+            if result:
+                print(f"  Standalone Final Result (Placeholder/Accumulated): {result}")
+            else:
+                print("  Standalone Execution might have failed or returned None (check logs above).")
+        except Exception as e:
+            print(f"\nStandalone Execution Test: FAILED - An unexpected error occurred: {e}")
+
+    print("\n--- MCP Tool Manager Test Finished (Standalone) ---")
+
+
+if __name__ == "__main__":
+    if sys.version_info < (3, 7):
+        print("ERROR: This script requires Python 3.7 or higher for asyncio.run().")
+        sys.exit(1)
+
+    if MCPToolManager is None:
+        print("Cannot run standalone tests because MCPToolManager failed to import.")
+        sys.exit(1)
+
+    asyncio.run(run_standalone_tests())


### PR DESCRIPTION
Adds support for MCP tools (first part)
- Currently this is implemented as a new module which could be shareable between agent backends.
- For now it does also contain some OpenAI type tool support (but other llm backends may need this)
- A test is included, but will not be run automatically as depends on having an MCP SSE server active
- The OpenAI agent run method will initiatialise the tool list

In progress/todo
 - Ensuring OpenAI agent can call a tool 
 - clean up output/debug 

Future PR:
 - Update/add schemas / deployment info / environment variables to allow the specification of MCP endpoints & any prompt changes etc