### PR TITLE
demo: new summary demo to align w/clients needs

### DIFF
--- a/maestro/demos/README.md
+++ b/maestro/demos/README.md
@@ -87,7 +87,7 @@ curl -X POST http://localhost:11434/api/generate -d '{
 
 #### Allowing maestro to be run from anywhere
 
-Modify wrapper script: `nano ~/.local/bin/maestro`
+Create wrapper script: `nano ~/.local/bin/maestro`
 Set the script path to run relative to your location, whereever in the terminal:
 
 ```bash

--- a/maestro/demos/README.md
+++ b/maestro/demos/README.md
@@ -85,6 +85,20 @@ curl -X POST http://localhost:11434/api/generate -d '{
 }'
 ```
 
+#### Allowing maestro to be run from anywhere
+
+Modify wrapper script: `nano ~/.local/bin/maestro`
+Set the script path to run relative to your location, whereever in the terminal:
+
+```bash
+#!/bin/bash
+export PYTHONPATH="/Users/REPLACEwUser/Desktop/work/bee-hive:$PYTHONPATH"
+python3 -m maestro.cli.maestro "$@"
+```
+
+Make sure the script is executable: `chmod +x ~/.local/bin/maestro`
+Verify maestro is running properly: `maestro --help`
+
 ##### SlackBot support
 
 Please set `SLACK_BOT_TOKEN` and `SLACK_TEAM_ID` as environment variables. See `./tests/yamls/agents/slack_agent.yaml` and `./tests/yamls/workflow_agent.yaml` for details. The output of slack message will be whatever is passed into the prompt.

--- a/maestro/demos/workflows/summary.ai/README.md
+++ b/maestro/demos/workflows/summary.ai/README.md
@@ -1,6 +1,6 @@
 # Summary.ai Example
 
-A multi-agent workflow using Maestro: Allows an user to specify a topic from Arxiv they want to look at, choose a number of potential papers to summarize.
+A multi-agent workflow using Maestro: Allows user to retrieve the latests ArXiV papers published by IBM specified by category (arxiv tags), and release time period from today. Then, generates a summary from metadata and abstract that is retrieved.
 
 ## Mermaid Diagram
 
@@ -38,20 +38,6 @@ end
 
 * Copy `.env` to common directory: `cp .env ./../common/src`
 
-### Allowing maestro to be run from anywhere
-
-Modify wrapper script: `nano ~/.local/bin/maestro`
-Set the script path to run relative to your location, whereever in the terminal:
-
-```bash
-#!/bin/bash
-export PYTHONPATH="/Users/REPLACEwUser/Desktop/work/bee-hive:$PYTHONPATH"
-python3 -m maestro.cli.maestro "$@"
-```
-
-Make sure the script is executable: `chmod +x ~/.local/bin/maestro`
-Verify maestro is running properly: `maestro --help`
-
 ## Running the Workflow
 
 Assuming you are in maestro top level:
@@ -60,76 +46,91 @@ Assuming you are in maestro top level:
 
 To run the workflow:
 
-If you already created the agents and enabled the tool: `maestro run None ./demos/workflows/summary.ai/workflow.yaml`
-
-OR
-
-Directly run the workflow: `maestro run ./demos/workflows/summary.ai/agents.yaml ./demos/workflows/summary.ai/workflow.yaml`
-
-If in the actual demo directory, you can also directly run using: `./run.sh`.
+If you already created the agents and enabled necessary tools: `maestro run ./demos/workflows/summary.ai/workflow.yaml`
 
 ### NOTE: Custom Tools Required for this Demo
 
 Go into the UI and make 2 tools for this demo:
 
-1) Fetch tool:
-
-Name: Fetch
+1) Name: ibm-arXiv
 
 Code:
 
 ```Python
-import urllib.request
+import arxiv
+import feedparser
+from datetime import datetime, timedelta, timezone
+from typing import List, Dict
+from urllib.parse import urlencode
 
-def fetch_arxiv_titles(topic: str, k: int = 10):
-  """Fetches the k most recent article titles from arXiv on a given topic."""
-  url = f"http://export.arxiv.org/api/query?search_query=all:{topic}&sortBy=submittedDate&sortOrder=descending&max_results={k}"
-
-  with urllib.request.urlopen(url) as response:
-      data = response.read().decode()
-
-  titles = [line.split("<title>")[1].split("</title>")[0] for line in data.split("\n") if "<title>" in line][1:k+1]
-  return titles
-```
-
-2) Filtering tool:
-
-Name: Filter
-
-Code:
-
-```Python
-import urllib.request
-import urllib.parse
-import re
-
-def fetch_valid_arxiv_titles(titles: list):
+def find_ibm_papers(category: str, since_days: int) -> List[Dict]:
     """
-    Fetches titles that have an available abstract on ArXiv.
-
-    Args:
-        titles (list): List of paper titles.
-
-    Returns:
-        list: Titles that have an abstract.
+    Search ArXiv in `category`, pre-filter by abstract keywords, then
+    post-filter by author affiliation tags—handling URL encoding properly.
     """
-    base_url = "http://export.arxiv.org/api/query?search_query="
-    valid_titles = []
 
-    for title in titles:
-        search_query = f'all:"{urllib.parse.quote(title)}"'
-        url = f"{base_url}{search_query}&max_results=1"
-        try:
-            with urllib.request.urlopen(url) as response:
-                data = response.read().decode()
-        except Exception as e:
+    ibm_keywords = ["ibm", "watson", "powerai", "ibm research"]
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=since_days)
+    abs_filter = " OR ".join(f'abs:"{kw}"' for kw in ibm_keywords)
+    query = f"cat:{category} AND ({abs_filter})"
+    params = {
+        "search_query": query,
+        "start": 0,
+        "max_results": 100,
+        "sortBy": "submittedDate",
+        "sortOrder": "descending",
+    }
+    base_url = "http://export.arxiv.org/api/query?"
+    url = base_url + urlencode(params)
+
+    feed = feedparser.parse(url)
+    papers = []
+
+    for entry in feed.entries:
+        published = datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
+        if published < cutoff:
             continue
 
-        abstract_match = re.search(r"<summary>(.*?)</summary>", data, re.DOTALL)
+        abstract = entry.summary.lower()
+        keyword_match = any(kw.lower() in abstract for kw in ibm_keywords)
 
-        if abstract_match:
-            valid_titles.append(title)
-        else:
-            print(f"❌ No abstract found: {title}")
-    return valid_titles
+        affs = entry.get("arxiv_affiliation", [])
+        affiliation_match = any("ibm" in aff.lower() for aff in affs)
+
+        if not (keyword_match or affiliation_match):
+            continue
+
+        papers.append(entry.title)
+
+    return papers
+```
+
+2) Name: get_metadata
+
+Code:
+
+```Python
+import arxiv
+from typing import Optional
+
+def get_metadata_by_title(title: str) -> Optional[str]:
+    """
+    Given the exact title of an arXiv paper, fetch its abstract.
+    Returns None if no match is found.
+    """
+    client = arxiv.Client()
+    search = arxiv.Search(
+        query=f'ti:"{title}"',
+        max_results=1
+    )
+    result = next(client.results(search), None)
+    if not result:
+        return None
+    return {
+        "title":     result.title,
+        "authors":   [a.name for a in result.authors],
+        "published": result.published.strftime("%Y-%m-%d"),
+        "abstract":  result.summary.strip()
+    }
 ```

--- a/maestro/demos/workflows/summary.ai/README.md
+++ b/maestro/demos/workflows/summary.ai/README.md
@@ -52,7 +52,7 @@ If you already created the agents and enabled necessary tools: `maestro run ./de
 
 Go into the UI and make 2 tools for this demo:
 
-1) Name: ibm-arXiv
+##### Name: ibm-arXiv
 
 Code:
 
@@ -106,7 +106,7 @@ def find_ibm_papers(category: str, since_days: int) -> List[Dict]:
     return papers
 ```
 
-2) Name: get_metadata
+##### Name: get_metadata
 
 Code:
 

--- a/maestro/demos/workflows/summary.ai/README.md
+++ b/maestro/demos/workflows/summary.ai/README.md
@@ -7,19 +7,19 @@ A multi-agent workflow using Maestro: Allows an user to specify a topic from Arx
 <!-- MERMAID_START -->
 ```mermaid
 sequenceDiagram
-participant paper retriever
-participant Abstract Agent
-participant Summary Agent
-participant Choose Paper
-paper retriever->>Choose Paper: retreive papers
-Choose Paper->>Abstract Agent: choose paper
-Abstract Agent->>Summary Agent: retrieve abstract
-Summary Agent->>Summary Agent: get summary
+participant Paper Finder
+participant get metadata
+participant generate summary
+participant slack
+Paper Finder->>get metadata: Step1
+get metadata->>generate summary: Step2
+generate summary->>slack: Step3
+slack->>slack: Step4
 alt cron "0 0 * * *"
-  cron->>paper retriever: retreive papers
-  cron->>Choose Paper: choose paper
-  cron->>Abstract Agent: retrieve abstract
-  cron->>Summary Agent: get summary
+  cron->>None: Paper Finder
+  cron->>None: get metadata
+  cron->>None: generate summary
+  cron->>None: slack
 else
   cron->>exit: True
 end

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -170,3 +170,44 @@ spec:
             papers.append(entry.title)
 
         return papers
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: get metadata
+  labels:
+    app: mas-example 
+spec:
+  model: llama3.1
+  framework: beeai
+  mode: remote
+  description: "Retrieve metadata for a given arxiv paper"
+  instructions: |
+    The input will be a title to a research paper from arxiv, which we can call `title`. This will be used as a parameter for the function in step 1. 
+
+    Step1:
+    Use the get_abstract tool, passing in the given title to retreive the abstract for the paper.  The function call should just be `get_abstract_by_title(title)`.
+  code: |
+    import arxiv
+    from typing import Optional
+
+    def get_abstract_by_title(title: str) -> Optional[str]:
+        """
+        Given the exact title of an arXiv paper, fetch its abstract.
+        Returns None if no match is found.
+        """
+        client = arxiv.Client()
+        search = arxiv.Search(
+            query=f'ti:"{title}"',
+            max_results=1
+        )
+        result = next(client.results(search), None)
+        if not result:
+            return None
+        return {
+            "title":     result.title,
+            "authors":   [a.name for a in result.authors],
+            "published": result.published.strftime("%Y-%m-%d"),
+            "abstract":  result.summary.strip()
+        }

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -170,6 +170,8 @@ spec:
             papers.append(entry.title)
 
         return papers
+  tools:
+    - 'ibm-arXiv'
 
 ---
 apiVersion: maestro/v1alpha1
@@ -211,3 +213,26 @@ spec:
             "published": result.published.strftime("%Y-%m-%d"),
             "abstract":  result.summary.strip()
         }
+  tools:
+    - 'get_abstract_by_title'
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: generate summary
+  labels:
+    app: mas-example 
+spec:
+  model: llama3.1
+  framework: beeai
+  mode: remote
+  description: "Retrieve metadata for a given arxiv paper"
+  instructions: |
+    You will be given the metadata to an arxiv research paper, including categories like title, author, date published, and abstract. Use all these fields to generate a formatted text summary. In addition to this, please add onto/extend the abstract to be more comprehensive as a whole, explaining terms, ideas, concepts that might be difficult to understand.
+
+    Example output:
+    Title, by Authors, published date.
+    Augmented abstract/summary....
+  tools: 
+    - 'LLM'

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -157,6 +157,7 @@ spec:
   instructions: |
     You will be given the metadata to an arxiv research paper as input, including categories like title, author, date published, and abstract. 
     Use all these input information to generate a formatted text summary. In addition to this, please add onto/extend the abstract to be more comprehensive as a whole, explaining terms, ideas, concepts that might be difficult to understand. 
+    *Do not output anything other than the generated summary, and directly print it from the result step*. Make sure it follows the example output format.
 
     Example output:
     Title, by Authors, published date.

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -99,3 +99,74 @@ spec:
   mode: remote
   description: slack agent
   instructions: post a message to slack
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: Paper Finder
+  labels:
+    app: mas-example 
+spec:
+  model: llama3.1
+  framework: beeai
+  mode: remote
+  description: "Retrieve IBM related papers from a certain topic in a certain time frame"
+  instructions: |
+    Input:
+          • category (string)           # e.g. "quantum-ph"
+          • since_days (int)  # e.g. "1" for the last 1 days since today's date.
+
+        Task:
+          1. Call the ibm-arXiv tool to search for all papers on `category` published in the last `since_days`. All the functionality is already implemented in the funciton, simply execute the function with the given parameters as the input, and then return the output (which should be titles of research papers) into a list.
+  code: |
+    import arxiv
+    import feedparser
+    from datetime import datetime, timedelta, timezone
+    from typing import List, Dict
+    from urllib.parse import urlencode
+
+    def find_ibm_papers(
+        category: str,
+        since_days: int,
+    ) -> List[Dict]:
+        """
+        Search ArXiv in `category`, pre-filter by abstract keywords, then
+        post-filter by author affiliation tags—handling URL encoding properly.
+        """
+      
+        ibm_keywords = ["ibm", "watson", "powerai", "ibm research"]
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=since_days)
+        abs_filter = " OR ".join(f'abs:"{kw}"' for kw in ibm_keywords)
+        query = f"cat:{category} AND ({abs_filter})"
+        params = {
+            "search_query": query,
+            "start": 0,
+            "max_results": 100,
+            "sortBy": "submittedDate",
+            "sortOrder": "descending",
+        }
+        base_url = "http://export.arxiv.org/api/query?"
+        url = base_url + urlencode(params)
+
+        feed = feedparser.parse(url)
+        papers = []
+
+        for entry in feed.entries:
+            published = datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
+            if published < cutoff:
+                continue
+
+            abstract = entry.summary.lower()
+            keyword_match = any(kw.lower() in abstract for kw in ibm_keywords)
+
+            affs = entry.get("arxiv_affiliation", [])
+            affiliation_match = any("ibm" in aff.lower() for aff in affs)
+
+            if not (keyword_match or affiliation_match):
+                continue
+
+            papers.append(entry.title)
+
+        return papers

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -119,6 +119,7 @@ spec:
 
         Task:
           1. Call the ibm-arXiv tool to search for all papers on `category` published in the last `since_days`. All the functionality is already implemented in the funciton, simply execute the function with the given parameters as the input, and then return the output (which should be titles of research papers) into a list.
+          Directly print out the list in the output.
   code: |
     import arxiv
     import feedparser
@@ -189,12 +190,25 @@ spec:
     The input will be a title to a research paper from arxiv, which we can call `title`. This will be used as a parameter for the function in step 1. 
 
     Step1:
-    Use the get_abstract tool, passing in the given title to retreive the abstract for the paper.  The function call should just be `get_abstract_by_title(title)`.
+    Use the get_metadata tool, passing in the given title to retreive the abstract for the paper.  The function call should just be `get_metadata_by_title(title)`. 
+
+    Currently you are using the Thought, Result, and Reason step which is the final output that is generated. However, I want you to stop at the Result step (which should directly just be the output of the function).
+    *STRICTLY output the result of the function and nothing else*
+
+    Example output that the user should see:
+    {
+      "title": inputted title,
+      "authors": [
+          actual authors retrieved by the function
+      ],
+      "published": actual date retrieved by the function,
+      "abstract": actual abstract retrieved by the function
+    }
   code: |
     import arxiv
     from typing import Optional
 
-    def get_abstract_by_title(title: str) -> Optional[str]:
+    def get_metadata_by_title(title: str) -> Optional[str]:
         """
         Given the exact title of an arXiv paper, fetch its abstract.
         Returns None if no match is found.
@@ -214,7 +228,7 @@ spec:
             "abstract":  result.summary.strip()
         }
   tools:
-    - 'get_abstract_by_title'
+    - 'get_metadata_by_title'
 
 ---
 apiVersion: maestro/v1alpha1

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -1,91 +1,3 @@
-# apiVersion: maestro/v1alpha1
-# kind: Agent
-# metadata:
-#   name: Abstract Agent
-#   labels:
-#     app: mas-example 
-# spec:
-#   model: llama3.1
-#   framework: beeai
-#   mode: remote
-#   description: "Get the abstract of the desired paper."
-#   instructions: |
-#     "You will be given the title of a research paper from arXiv. Your task is to use the arXiv tool to search for the paper by using only the provided paper title as your search parameter. Once you have located the paper, retrieve its summary (abstract) and output it directly here in a markdown format for readability. Do not use any SQL queries or database commands."
-#   tools: 
-#     - 'arxiv'
-
-# ---
-# apiVersion: maestro/v1alpha1
-# kind: Agent
-# metadata:
-#   name: Summary Agent
-#   labels:
-#     app: mas-example 
-# spec:
-#   model: llama3.1
-#   framework: beeai
-#   mode: remote
-#   description: "Get the summary of the desired paper"
-#   instructions: |
-#     You will be given an abstract of a research paper. Your job is to expand on it and generate a summary from it. Make sure the concept is more clear, try to make the summary long and detailed. Go into detail about each topic mentioned. Please add onto the summary. Produce your final answer/summary in a single markdown code block, Show everything directly in the final output.
-
-#     Example output {the following below should be in a code block):
-
-#     ```markdown
-#     The summary/output you generated
-#     ```
-#   tools: 
-#     - 'LLM'
-
-# ---
-# apiVersion: maestro/v1alpha1
-# kind: Agent
-# metadata:
-#   name: Choose Paper
-#   labels:
-#     app: mas-example 
-# spec:
-#   model: llama3.1
-#   framework: beeai
-#   mode: remote
-#   description: "Choose a paper from the list of titles."
-#   instructions: |
-#     You will be provided a list of titles, simply output one at random. Note, the outputted title must be in the list.
-
-#     Example:
-#     Input: [`title1`, `title2`, `title3`]
-#     Output: `title3`
-    
-# ---
-# apiVersion: maestro/v1alpha1
-# kind: Agent
-# metadata:
-#   name: paper retriever
-#   labels:
-#     app: mas-example 
-# spec:
-#   model: llama3.1
-#   framework: beeai
-#   mode: remote
-#   description: "Choose a paper from the list of titles."
-#   instructions: |
-#     Input: A topic (string) and a number n (integer) indicating how many papers to retrieve.
-
-#     Task:
-#     Use the arXiv tool to search for the most recent papers related to the given topic. Do not perform any SQL queries or database commands, use the tool directly to get these papers.
-#     Retrieve exactly n papers sorted by their publication date (most recent first).
-#     Extract only the titles of these papers.
-#     Output the titles in a list format (i.e., a Python list). Do not include any additional text or formatting.
-
-#     Example Input:
-#     topic: "quantum", n: 2
-
-#     Output:
-#     ['title1_related_quantum', 'title2_quantum']
-#   tools: 
-#     - 'arxiv'
-
-# ---
 apiVersion: maestro/v1alpha1
 kind: Agent
 metadata:
@@ -114,7 +26,7 @@ spec:
   description: "Retrieve IBM related papers from a certain topic in a certain time frame"
   instructions: |
     Input:
-          • category (string)           # e.g. "quantum-ph"
+          • category (string) # e.g. "quantum-ph"
           • since_days (int)  # e.g. "1" for the last 1 days since today's date.
 
         Task:

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -243,7 +243,8 @@ spec:
   mode: remote
   description: "Retrieve metadata for a given arxiv paper"
   instructions: |
-    You will be given the metadata to an arxiv research paper, including categories like title, author, date published, and abstract. Use all these fields to generate a formatted text summary. In addition to this, please add onto/extend the abstract to be more comprehensive as a whole, explaining terms, ideas, concepts that might be difficult to understand.
+    You will be given the metadata to an arxiv research paper as input, including categories like title, author, date published, and abstract. 
+    Use all these input information to generate a formatted text summary. In addition to this, please add onto/extend the abstract to be more comprehensive as a whole, explaining terms, ideas, concepts that might be difficult to understand. 
 
     Example output:
     Title, by Authors, published date.

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -84,3 +84,18 @@ spec:
     ['title1_related_quantum', 'title2_quantum']
   tools: 
     - 'arxiv'
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: slack
+  labels:
+    app: slack-example
+    custom_agent: slack_agent
+spec:
+  model: dummy
+  framework: custom
+  mode: remote
+  description: slack agent
+  instructions: post a message to slack

--- a/maestro/demos/workflows/summary.ai/agents.yaml
+++ b/maestro/demos/workflows/summary.ai/agents.yaml
@@ -1,91 +1,91 @@
-apiVersion: maestro/v1alpha1
-kind: Agent
-metadata:
-  name: Abstract Agent
-  labels:
-    app: mas-example 
-spec:
-  model: llama3.1
-  framework: beeai
-  mode: remote
-  description: "Get the abstract of the desired paper."
-  instructions: |
-    "You will be given the title of a research paper from arXiv. Your task is to use the arXiv tool to search for the paper by using only the provided paper title as your search parameter. Once you have located the paper, retrieve its summary (abstract) and output it directly here in a markdown format for readability. Do not use any SQL queries or database commands."
-  tools: 
-    - 'arxiv'
+# apiVersion: maestro/v1alpha1
+# kind: Agent
+# metadata:
+#   name: Abstract Agent
+#   labels:
+#     app: mas-example 
+# spec:
+#   model: llama3.1
+#   framework: beeai
+#   mode: remote
+#   description: "Get the abstract of the desired paper."
+#   instructions: |
+#     "You will be given the title of a research paper from arXiv. Your task is to use the arXiv tool to search for the paper by using only the provided paper title as your search parameter. Once you have located the paper, retrieve its summary (abstract) and output it directly here in a markdown format for readability. Do not use any SQL queries or database commands."
+#   tools: 
+#     - 'arxiv'
 
----
-apiVersion: maestro/v1alpha1
-kind: Agent
-metadata:
-  name: Summary Agent
-  labels:
-    app: mas-example 
-spec:
-  model: llama3.1
-  framework: beeai
-  mode: remote
-  description: "Get the summary of the desired paper"
-  instructions: |
-    You will be given an abstract of a research paper. Your job is to expand on it and generate a summary from it. Make sure the concept is more clear, try to make the summary long and detailed. Go into detail about each topic mentioned. Please add onto the summary. Produce your final answer/summary in a single markdown code block, Show everything directly in the final output.
+# ---
+# apiVersion: maestro/v1alpha1
+# kind: Agent
+# metadata:
+#   name: Summary Agent
+#   labels:
+#     app: mas-example 
+# spec:
+#   model: llama3.1
+#   framework: beeai
+#   mode: remote
+#   description: "Get the summary of the desired paper"
+#   instructions: |
+#     You will be given an abstract of a research paper. Your job is to expand on it and generate a summary from it. Make sure the concept is more clear, try to make the summary long and detailed. Go into detail about each topic mentioned. Please add onto the summary. Produce your final answer/summary in a single markdown code block, Show everything directly in the final output.
 
-    Example output {the following below should be in a code block):
+#     Example output {the following below should be in a code block):
 
-    ```markdown
-    The summary/output you generated
-    ```
-  tools: 
-    - 'LLM'
+#     ```markdown
+#     The summary/output you generated
+#     ```
+#   tools: 
+#     - 'LLM'
 
----
-apiVersion: maestro/v1alpha1
-kind: Agent
-metadata:
-  name: Choose Paper
-  labels:
-    app: mas-example 
-spec:
-  model: llama3.1
-  framework: beeai
-  mode: remote
-  description: "Choose a paper from the list of titles."
-  instructions: |
-    You will be provided a list of titles, simply output one at random. Note, the outputted title must be in the list.
+# ---
+# apiVersion: maestro/v1alpha1
+# kind: Agent
+# metadata:
+#   name: Choose Paper
+#   labels:
+#     app: mas-example 
+# spec:
+#   model: llama3.1
+#   framework: beeai
+#   mode: remote
+#   description: "Choose a paper from the list of titles."
+#   instructions: |
+#     You will be provided a list of titles, simply output one at random. Note, the outputted title must be in the list.
 
-    Example:
-    Input: [`title1`, `title2`, `title3`]
-    Output: `title3`
+#     Example:
+#     Input: [`title1`, `title2`, `title3`]
+#     Output: `title3`
     
----
-apiVersion: maestro/v1alpha1
-kind: Agent
-metadata:
-  name: paper retriever
-  labels:
-    app: mas-example 
-spec:
-  model: llama3.1
-  framework: beeai
-  mode: remote
-  description: "Choose a paper from the list of titles."
-  instructions: |
-    Input: A topic (string) and a number n (integer) indicating how many papers to retrieve.
+# ---
+# apiVersion: maestro/v1alpha1
+# kind: Agent
+# metadata:
+#   name: paper retriever
+#   labels:
+#     app: mas-example 
+# spec:
+#   model: llama3.1
+#   framework: beeai
+#   mode: remote
+#   description: "Choose a paper from the list of titles."
+#   instructions: |
+#     Input: A topic (string) and a number n (integer) indicating how many papers to retrieve.
 
-    Task:
-    Use the arXiv tool to search for the most recent papers related to the given topic. Do not perform any SQL queries or database commands, use the tool directly to get these papers.
-    Retrieve exactly n papers sorted by their publication date (most recent first).
-    Extract only the titles of these papers.
-    Output the titles in a list format (i.e., a Python list). Do not include any additional text or formatting.
+#     Task:
+#     Use the arXiv tool to search for the most recent papers related to the given topic. Do not perform any SQL queries or database commands, use the tool directly to get these papers.
+#     Retrieve exactly n papers sorted by their publication date (most recent first).
+#     Extract only the titles of these papers.
+#     Output the titles in a list format (i.e., a Python list). Do not include any additional text or formatting.
 
-    Example Input:
-    topic: "quantum", n: 2
+#     Example Input:
+#     topic: "quantum", n: 2
 
-    Output:
-    ['title1_related_quantum', 'title2_quantum']
-  tools: 
-    - 'arxiv'
+#     Output:
+#     ['title1_related_quantum', 'title2_quantum']
+#   tools: 
+#     - 'arxiv'
 
----
+# ---
 apiVersion: maestro/v1alpha1
 kind: Agent
 metadata:
@@ -171,7 +171,7 @@ spec:
 
         return papers
   tools:
-    - 'ibm-arXiv'
+    - 'find_ibm_papers'
 
 ---
 apiVersion: maestro/v1alpha1

--- a/maestro/demos/workflows/summary.ai/workflow.yaml
+++ b/maestro/demos/workflows/summary.ai/workflow.yaml
@@ -41,6 +41,7 @@ spec:
       - Paper Finder
       - get metadata
       - generate summary
+      - slack
     prompt: find_ibm_papers("stat.ML",30)
     steps:
       - name: Step1
@@ -49,3 +50,5 @@ spec:
         agent: get metadata
       - name: Step3
         agent: generate summary
+      - name: Step4
+        agent: slack

--- a/maestro/demos/workflows/summary.ai/workflow.yaml
+++ b/maestro/demos/workflows/summary.ai/workflow.yaml
@@ -10,30 +10,42 @@ spec:
       name: summary-ai
       labels:
         project: maestro-demo
-    event:
-      cron: "0 0 * * *"
-      name: daily run
-      steps:
-        - retreive papers
-        - choose paper
-        - retrieve abstract
-        - get summary
-      exit: "True"
+    # event:
+    #   cron: "0 0 * * *"
+    #   name: daily run
+    #   steps:
+    #     - retreive papers
+    #     - choose paper
+    #     - retrieve abstract
+    #     - get summary
+    #   exit: "True"
+    # agents:
+    #   - paper retriever
+    #   - Abstract Agent
+    #   - Summary Agent
+    #   - Choose Paper
+    #   - slack
+    # prompt: topic = quantum, n=2
+    # steps:
+    #   - name: retreive papers
+    #     agent: paper retriever
+    #   - name: choose paper
+    #     agent: Choose Paper
+    #   - name: retrieve abstract 
+    #     agent: Abstract Agent
+    #   - name: get summary
+    #     agent: Summary Agent
+    #   - name: slackstep
+    #     agent: slack
     agents:
-      - paper retriever
-      - Abstract Agent
-      - Summary Agent
-      - Choose Paper
-      - slack
-    prompt: topic = quantum, n=2
+      - Paper Finder
+      - get metadata
+      - generate summary
+    prompt: find_ibm_papers("stat.ML",30)
     steps:
-      - name: retreive papers
-        agent: paper retriever
-      - name: choose paper
-        agent: Choose Paper
-      - name: retrieve abstract 
-        agent: Abstract Agent
-      - name: get summary
-        agent: Summary Agent
-      - name: slackstep
-        agent: slack
+      - name: Step1
+        agent: Paper Finder
+      - name: Step2
+        agent: get metadata
+      - name: Step3
+        agent: generate summary

--- a/maestro/demos/workflows/summary.ai/workflow.yaml
+++ b/maestro/demos/workflows/summary.ai/workflow.yaml
@@ -19,24 +19,6 @@ spec:
     #     - retrieve abstract
     #     - get summary
     #   exit: "True"
-    # agents:
-    #   - paper retriever
-    #   - Abstract Agent
-    #   - Summary Agent
-    #   - Choose Paper
-    #   - slack
-    # prompt: topic = quantum, n=2
-    # steps:
-    #   - name: retreive papers
-    #     agent: paper retriever
-    #   - name: choose paper
-    #     agent: Choose Paper
-    #   - name: retrieve abstract 
-    #     agent: Abstract Agent
-    #   - name: get summary
-    #     agent: Summary Agent
-    #   - name: slackstep
-    #     agent: slack
     agents:
       - Paper Finder
       - get metadata

--- a/maestro/demos/workflows/summary.ai/workflow.yaml
+++ b/maestro/demos/workflows/summary.ai/workflow.yaml
@@ -24,6 +24,7 @@ spec:
       - Abstract Agent
       - Summary Agent
       - Choose Paper
+      - slack
     prompt: topic = quantum, n=2
     steps:
       - name: retreive papers
@@ -34,3 +35,5 @@ spec:
         agent: Abstract Agent
       - name: get summary
         agent: Summary Agent
+      - name: slackstep
+        agent: slack

--- a/maestro/demos/workflows/summary.ai/workflow.yaml
+++ b/maestro/demos/workflows/summary.ai/workflow.yaml
@@ -10,15 +10,15 @@ spec:
       name: summary-ai
       labels:
         project: maestro-demo
-    # event:
-    #   cron: "0 0 * * *"
-    #   name: daily run
-    #   steps:
-    #     - retreive papers
-    #     - choose paper
-    #     - retrieve abstract
-    #     - get summary
-    #   exit: "True"
+    event:
+      cron: "0 0 * * *"
+      name: daily run
+      steps:
+        - Paper Finder
+        - get metadata
+        - generate summary
+        - slack
+      exit: "True"
     agents:
       - Paper Finder
       - get metadata


### PR DESCRIPTION
fully redesigned summary ai using agents in order to support the following client needs:

1) Know when new IBM papers hit the ArXiv
2) Search ArXiv for papers on a certain topic during a certain time period (only for IBM documents)
3) Retreive metadata, create summary for certain paper
4) Send the summary to your slack

future updates:
1A) Look into creating own tool in python that can create better summary from PDF
1B) Currently only output of first agent is something like this ['title1','title2', etc]. Currently the rest of the agents only can handle one title at a time, but I need support for a loop or parallel with each title in output @akihikokuroda 
...
2) Support for non ibm docs? (could be a lot slower because the freuqency of released docs are much higher)
