### PR TITLE
test: fix buggy streamlit tests

### DIFF
--- a/src/maestro/cli/commands.py
+++ b/src/maestro/cli/commands.py
@@ -333,7 +333,7 @@ class DeployCmd(Command):
     def __deploy_agents_workflow_streamlit(self):
         try:
             sys.argv = ["uv", "run", "streamlit", "run", "--ui.hideTopBar", "True", "--client.toolbarMode", "minimal", f"{os.path.dirname(__file__)}/streamlit_deploy.py", self.AGENTS_FILE(), self.WORKFLOW_FILE()]
-            process = subprocess.Popen(sys.argv)
+            self.process = subprocess.Popen(sys.argv)
         except Exception as e:
             self._check_verbose()
             raise RuntimeError(f"{str(e)}") from e
@@ -369,9 +369,7 @@ class DeployCmd(Command):
         return self.args['--url'] 
 
     def k8s(self):
-        if self.args['--k8s'] != "":
-            return self.args['--k8s']
-        return self.args['--kubernetes'] 
+        return self.args['--k8s'] or self.args['--kubernetes']
 
     def docker(self):
         return self.args['--docker']
@@ -479,8 +477,8 @@ class MetaAgentsCmd(Command):
     # private    
     def __meta_agents(self, text_file) -> int:
         try:
-            sys.argv = ["uv", "run", "streamlit", "run", "--ui.hideTopBar", "True", "--client.toolbarMode", "minimal", f"{os.path.dirname(__file__)}/cli/streamlit_meta_agents_deploy.py", text_file]
-            process = subprocess.Popen(sys.argv)
+            sys.argv = ["uv", "run", "streamlit", "run", "--ui.hideTopBar", "True", "--client.toolbarMode", "minimal", f"{os.path.dirname(__file__)}/streamlit_meta_agents_deploy.py", text_file]
+            self.process = subprocess.Popen(sys.argv)
         except Exception as e:
             self._check_verbose()
             raise RuntimeError(f"{str(e)}") from e

--- a/src/maestro/cli/streamlit_meta_agents_deploy.py
+++ b/src/maestro/cli/streamlit_meta_agents_deploy.py
@@ -14,7 +14,7 @@ from streamlit.runtime.scriptrunner import add_script_run_ctx,get_script_run_ctx
 
 from maestro.cli.streamlit_workflow_ui import StreamlitWorkflowUI
 
-from maestro.common import Console, read_file
+from maestro.cli.common import Console, read_file
 
 def deploy_meta_agents_streamlit(prompt_text_file):
     """Deploy and run meta-agents workflow using Streamlit UI.
@@ -52,10 +52,11 @@ def deploy_meta_agents_streamlit(prompt_text_file):
             {"role": "assistant", "content": "Welcome to Maestro meta-agents workflow"}
         ]
 
-    image_path = str(files("maestro").joinpath("images/maestro.png"))
+    def pkg_path(local_path: str) -> str:
+        return str(files("maestro").joinpath(local_path))
 
     # Page header
-    st.image(image_path, width=200)
+    st.image(pkg_path("images/maestro.png"), width=200)
     st.title("Maestro Meta-Agents workflows")
 
     # Set tabs for: Meta-Agents agents and workflow workflows and the generated workflow
@@ -63,12 +64,12 @@ def deploy_meta_agents_streamlit(prompt_text_file):
 
     with agents_tab:
         st.header("Meta-agents 🤖 -> agents.yaml")
-        ma_agents_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_agent.yaml', prompt, 'Maestro meta-agents agents workflow', generated_agent)
+        ma_agents_workflow_ui = StreamlitWorkflowUI(pkg_path('agents/meta_agent/agents.yaml'), pkg_path('agents/meta_agent/workflow_agent.yaml'), prompt, 'Maestro meta-agents agents workflow', generated_agent)
         ma_agents_workflow_ui.setup_ui()
-    
+
     with workflow_tab:
         st.header("Meta-agents 🤖 -> workflow.yaml")
-        ma_workflow_workflow_ui = StreamlitWorkflowUI('src/agents/meta_agent/agents.yaml', 'src/agents/meta_agent/workflow_workflow.yaml', prompt, 'Maestro meta-agents workflow', generated_workflow)
+        ma_workflow_workflow_ui = StreamlitWorkflowUI(pkg_path('agents/meta_agent/agents.yaml'), pkg_path('agents/meta_agent/workflow_workflow.yaml'), prompt, 'Maestro meta-agents workflow', generated_workflow)
         ma_workflow_workflow_ui.setup_ui()
 
     with generated_workflow_tab:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -354,6 +354,7 @@ class MetaAgentsCommandTest(TestCommand):
         self.command = CLI(self.args).command()
     
     def tearDown(self):
+        self.command.process.kill() if self.command.process is not None else None
         self.args = {}
         self.command = None
         


### PR DESCRIPTION
Fixes #562 

Address some silently failing tests:
- the `--kubernetes` flag was being ignored causing the `test_deploy__dry_run_kubernetes` test to run a not mocked local deploy and start streamlit
- `test_meta_agents` was silently failing due to some missed uv updates to `streamlit_meta_agents_deploy.py`, ionce fixed it now spins up a streamlit instance, which I added a cleanup step for.