### PR TITLE
bug: fix release CI and prep patch release

### DIFF
--- a/.github/workflows/maestro_build_upload_images.yaml
+++ b/.github/workflows/maestro_build_upload_images.yaml
@@ -35,19 +35,22 @@ jobs:
           activate-environment: true
       - name: Build Maestro
         run: uv build
+      - name: get docker-compatible GITHUB_ORG
+        run: |
+          echo "GITHUB_ORG=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
       - name: Build and push the image
         id: build_push
-        env:
-          GITHUB_ORG: ${{ github.repository_owner }}
         run : |
           VERSION=$(grep -E '^(version|tool\.poetry\.version) *= *"[^"]+"' "pyproject.toml" | \
             head -n 1 | \
             sed -E 's/.*"([^"]+)".*/\1/')
           uv run tools/buildimg.sh
-          docker tag ghcr.io/${{ github.repository_owner }}/maestro:$VERSION ghcr.io/${{ github.repository_owner }}/maestro:$VERSION-${{ matrix.arch }}
-          docker tag ghcr.io/${{ github.repository_owner }}/maestro-cli:$VERSION ghcr.io/${{ github.repository_owner }}/maestro-cli:$VERSION-${{ matrix.arch }}
-          docker push ghcr.io/${{ github.repository_owner }}/maestro:$VERSION-${{ matrix.arch }}
-          docker push ghcr.io/${{ github.repository_owner }}/maestro-cli:$VERSION-${{ matrix.arch }}
+          docker tag ghcr.io/$GITHUB_ORG/maestro:$VERSION ghcr.io/$GITHUB_ORG/maestro:$VERSION-${{ matrix.arch }}
+          docker tag ghcr.io/$GITHUB_ORG/maestro-cli:$VERSION ghcr.io/$GITHUB_ORG/maestro-cli:$VERSION-${{ matrix.arch }}
+          docker push ghcr.io/$GITHUB_ORG/maestro:$VERSION-${{ matrix.arch }}
+          docker push ghcr.io/$GITHUB_ORG/maestro-cli:$VERSION-${{ matrix.arch }}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
   upload-manifest:
     needs: build-upload
@@ -58,13 +61,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: get docker-compatible GITHUB_ORG
+        run: |
+          echo "GITHUB_ORG=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
       - name: Push multiarch image to ghcr.io
         run: |
-          docker manifest create ghcr.io/${{ github.repository_owner }}/maestro:${{ needs.build-upload.outputs.version }} \
-            --amend ghcr.io/${{ github.repository_owner }}/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
-            --amend ghcr.io/${{ github.repository_owner }}/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
-          docker manifest create ghcr.io/${{ github.repository_owner }}/maestro-cli:${{ needs.build-upload.outputs.version }} \
-            --amend ghcr.io/${{ github.repository_owner }}/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
-            --amend ghcr.io/${{ github.repository_owner }}/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
-          docker manifest push ghcr.io/${{ github.repository_owner }}/maestro:${{ needs.build-upload.outputs.version }}
-          docker manifest push ghcr.io/${{ github.repository_owner }}/maestro-cli:${{ needs.build-upload.outputs.version }}
+          docker manifest create ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }} \
+            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
+            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
+          docker manifest create ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }} \
+            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
+            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
+          docker manifest push ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}
+          docker manifest push ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }}

--- a/.github/workflows/maestro_release.yaml
+++ b/.github/workflows/maestro_release.yaml
@@ -86,6 +86,8 @@ jobs:
   release:
     needs: [build, verify]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /usr/src/app
 
-ARG MAESTRO_VERSION="0.3.0"
+ARG MAESTRO_VERSION="0.3.1"
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maestro"
-version = "0.3.0"
+version = "0.3.1"
 description = "A multi-agent platform with the vision to facilitate deploy and run AI agents."
 authors = [
     {name = "IBM"}


### PR DESCRIPTION
The release CI had a couple bugs that were hit when `v0.3.0` was cut (https://github.com/AI4quantum/maestro/actions):

- the docker image release assumed the user/org name was all lowercase, AI4quantum is not, so a "to lower" step needed to be added (the step used was the recommended one by the community)
- the GitHub releaser action we used needs write permissions to cut a release, by default a user has write permissions on their own repos (like forks). When releasing on an org though the perms need to be explicitly given

I also incremented the version to 0.3.1 so we can cut a `v0.3.1` tag once this is merged and the release process should work as intended