### PR TITLE
chore: add latest tag for docker images

### DIFF
--- a/.github/workflows/maestro_build_upload_images.yaml
+++ b/.github/workflows/maestro_build_upload_images.yaml
@@ -78,5 +78,13 @@ jobs:
           docker manifest create ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }} \
             --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
             --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
+          docker manifest create ghcr.io/$GITHUB_ORG/maestro:latest \
+            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
+            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
+          docker manifest create ghcr.io/$GITHUB_ORG/maestro-cli:latest \
+            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-x86_64 \
+            --amend ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}-arm64 &&
           docker manifest push ghcr.io/$GITHUB_ORG/maestro:${{ needs.build-upload.outputs.version }}
           docker manifest push ghcr.io/$GITHUB_ORG/maestro-cli:${{ needs.build-upload.outputs.version }}
+          docker manifest push ghcr.io/$GITHUB_ORG/maestro:latest
+          docker manifest push ghcr.io/$GITHUB_ORG/maestro-cli:latest


### PR DESCRIPTION
Fixes #654

pushes a `latest` tag as well a a `#.#.#` tag for the docker images when doing a release. 